### PR TITLE
CSYS-216: Change spacing for top and bottom placements and add `bottom-start` placement

### DIFF
--- a/scss/components/_lab-tooltip.scss
+++ b/scss/components/_lab-tooltip.scss
@@ -51,7 +51,7 @@ $tooltip-border-color: map-get($tooltip-theme, "80");
     /* Placement modifiers */
 
     &.lab-tooltip--top-start {
-        top: calc(-50% - #{$spacing-2});
+        top: calc(-50% - #{$spacing-4});
         left: 0;
     }
 
@@ -59,12 +59,12 @@ $tooltip-border-color: map-get($tooltip-theme, "80");
         transform: translateX(-50%);
         -webkit-transform: translateX(-50%);
 
-        top: calc(-50% - #{$spacing-2});
+        top: calc(-50% - #{$spacing-4});
         left: 50%;
     }
 
     &.lab-tooltip--top-end {
-        top: calc(-50% - #{$spacing-2});
+        top: calc(-50% - #{$spacing-4});
         right: 0;
     }
 
@@ -106,7 +106,7 @@ $tooltip-border-color: map-get($tooltip-theme, "80");
 
     &.lab-tooltip--bottom-start {
         left: 0;
-        bottom: calc(-50% - #{$spacing-2});
+        bottom: calc(-50% - #{$spacing-4});
     }
 
     &.lab-tooltip--bottom {
@@ -114,12 +114,12 @@ $tooltip-border-color: map-get($tooltip-theme, "80");
         -webkit-transform: translateX(-50%);
 
         left: 50%;
-        bottom: calc(-50% - #{$spacing-2});
+        bottom: calc(-50% - #{$spacing-4});
     }
 
     &.lab-tooltip--bottom-end {
         right: 0;
-        bottom: calc(-50% - #{$spacing-2});
+        bottom: calc(-50% - #{$spacing-4});
     }
 
 }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -15,7 +15,6 @@ export default class Tooltip extends React.Component {
       "right-start",
       "right",
       "right-end",
-      "bottom-start",
       "left-start",
       "left",
       "left-end",

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -19,6 +19,7 @@ export default class Tooltip extends React.Component {
       "left-start",
       "left",
       "left-end",
+      "bottom-start",
       "bottom",
       "bottom-end",
     ]),


### PR DESCRIPTION
This PR is the couterpart to the similatly named PR on confetti-storybook. Please check the other project to see if things make sense together.

**Link to task:** https://labcodes.atlassian.net/browse/CSYS-216

**Staging app:** https://migrate-tooltip-qa--confetti-storybook.netlify.app/

**How to test:**
- open the staging app
- check that the Tooltip story positions the Tooltip a bit above/below for top/bottom placements instead of right next to the button
- check that the `bottom-start` position is available in the `placement` control

**Description of your solution:**
I've changed the spacings for top/bottom placement from `$spacing-2` to `$spacing-4`, as discussed with @falconedani , and added the `bottom-start` option to Tooltip's prop types.