### PR TITLE
Migrate dialogs

### DIFF
--- a/src/Dialog/MessageDialog.js
+++ b/src/Dialog/MessageDialog.js
@@ -1,12 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
+
+import Icon from "../Icon";
 import DialogWrapper from "./DialogWrapper";
 import { Button, OutlineButton } from "../Button";
-import Icon from "../Icon";
+import { ICON_TYPES } from "../constants";
 
 export default class MessageDialog extends React.Component {
   static propTypes = {
-    icon: PropTypes.string.isRequired,
+    icon: PropTypes.oneOf(ICON_TYPES).isRequired,
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
     buttonProps: PropTypes.exact({

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { Button, OutlineButton, TextButton } from "./Button";
 import { TextInput, PasswordInput, EmailInput } from "./Input";
 import { StandardSearch, InlineSearch } from "./Search";
 import { SimpleTag, TogglableTag, RemovableTag, DropdownTag } from "./Tags";
+import { StandardDialog, MessageDialog } from "./Dialog";
 
 import NarrowSidebar from "./Sidebar";
 import Alert from "./Alert";
@@ -35,4 +36,6 @@ export {
   Radio,
   Toggle,
   Tooltip,
+  StandardDialog,
+  MessageDialog,
 };


### PR DESCRIPTION
Please check and review the `confetti-storybook`'s counterpart to this PR, since they need to be merged together.

**Related to:** https://github.com/labcodes/confetti-storybook/pull/11

**Link to task:** https://labcodes.atlassian.net/browse/CSYS-194

**Staging app:** https://migrate-dialogs--confetti-storybook.netlify.app/

**How to test:**
- open the staging app
- check that the stories for Message and Standard Dialogs are working as intended

**Description of your solution:**
Added exports for Message and Standard Dialogs and ICON_TYPES as prop type for the Message Dialog