### PR TITLE
CSYS-200: Migrate narrow sidebar

### DIFF
--- a/scss/components/_lab-sidebar.scss
+++ b/scss/components/_lab-sidebar.scss
@@ -61,11 +61,8 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
 .lab-narrow-sidebar__header {
   display: flex;
   justify-content: space-between;
-  position: fixed;
-  width: 80%;
   padding: 16px 28px;
   flex-grow: 0;
-  z-index: 1;
   border-top-right-radius: $radius-default;
   background-color: $white;
   box-sizing: border-box;
@@ -93,6 +90,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
 .lab-narrow-sidebar__avatar {
   display: flex;
   align-items: center;
+  overflow: hidden;
 
   &-photo {
     width: 48px;
@@ -111,6 +109,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
     display: flex;
     flex-direction: column;
     margin-left: 20px;
+    max-width: 50%;
     color: $teal-70;
     font-weight: $weight-bold;
     font-family: $font-primary;
@@ -118,11 +117,11 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
 
     @include from($tablet) {
       display: none;
+      max-width: none;
     }
   }
 
   &-caption {
-    display: inline-flex;
     font-family: $font-primary;
     color: $black-50;
     font-weight: $weight-medium;
@@ -171,7 +170,6 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
   flex-direction: column;
   flex-grow: 1;
   padding: $spacing-1 0;
-  margin-top: 76px;
   border-top: $border-default transparent;
   border-bottom: $border-default transparent;
 
@@ -256,11 +254,16 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
   }
 }
 
+.lab-narrow-sidebar__avatar-text span,
 .lab-narrow-sidebar__item-label,
 .lab-narrow-sidebar__footer-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.lab-narrow-sidebar__item-label,
+.lab-narrow-sidebar__footer-label {
   max-width: 100%;
 }
 

--- a/src/Sidebar/FooterButton.js
+++ b/src/Sidebar/FooterButton.js
@@ -1,13 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Icon from "../Icon";
+import { ICON_TYPES } from "../constants";
 
 export default class FooterButton extends React.Component {
   static propTypes = {
     /** This is the button label. */
     label: PropTypes.string.isRequired,
     /** Sets the icon related to the button label. Default state: no icon. */
-    icon: PropTypes.string,
+    icon: PropTypes.oneOf(ICON_TYPES),
     /** Callback action to be executed when the FooterButton is clicked. */
     onClick: PropTypes.func.isRequired,
   };

--- a/src/Sidebar/Item.js
+++ b/src/Sidebar/Item.js
@@ -1,13 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import Icon from "../Icon";
+import { ICON_TYPES } from "../constants";
 
 export default class Item extends React.Component {
   static propTypes = {
     /** This is the item's label. */
     label: PropTypes.string.isRequired,
     /** Sets the icon related to the Item label. Default state: no icon. */
-    icon: PropTypes.string,
+    icon: PropTypes.oneOf(ICON_TYPES),
     /** Callback action to be executed when the Item is clicked. */
     onClick: PropTypes.func.isRequired,
     /** Defines if the current Item is the active one in the Sidebar. */


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/CSYS-200

**Staging app:** https://migrate-narrow-sidebar--confetti-storybook.netlify.app/

**How to test:**
- open the staging app;
- check that the narrow sidebar stories work as described on the task

**Description of your solution:**
Applied ICON_TYPES constant to the Narrow Sidebar's components and fixed a CSS issue on small devices, that made the avatar photo be squished by the avatar text.
