### PR TITLE
CSYS-295: Fix bulma imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labcodes/confetti-ds",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "Labcodes' design system, focused on accessibility and ease to use",
   "main": "dist/index.js",
   "husky": {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -3,6 +3,7 @@
 @import "~bulma/sass/utilities/all";
 @import "~bulma/sass/grid/all";
 @import "~bulma/sass/elements/container";
+@import "~bulma/sass/helpers/all";
 
 // Variables
 @import "variables/all";


### PR DESCRIPTION
**Link to task:**
https://labcodes.atlassian.net/browse/CSYS-295

**Description of your solution:**
This PR includes the import `~bulma/sass/helpers/all` in the main CSS imports of the project. It also bumbs the current project version from `0.1.0-alpha.3` to `0.1.0-alpha.4`. 