### PR TITLE
CSYS 296: Add tabindex the dialogs components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labcodes/confetti-ds",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Labcodes' design system, focused on accessibility and ease to use",
   "main": "dist/index.js",
   "husky": {

--- a/scss/components/_lab-dialog.scss
+++ b/scss/components/_lab-dialog.scss
@@ -207,6 +207,7 @@
   &.lab-dialog__close-button--message {
     display: flex;
     align-items: center;
+    justify-content: center;
   }
 
   &:focus {

--- a/src/Button/AbstractButton.js
+++ b/src/Button/AbstractButton.js
@@ -36,6 +36,8 @@ export default class AbstractButton extends React.Component {
     onClick: PropTypes.func,
     /** Makes the button expand to its container's full width. */
     fullWidth: PropTypes.bool,
+    /* Sets the order of which the elements will be focused on. Default value: 0. */
+    tabIndex: PropTypes.string,
   };
 
   static defaultProps = {
@@ -48,6 +50,7 @@ export default class AbstractButton extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
+    tabIndex: "0",
   };
 
   icon = () => {
@@ -81,6 +84,7 @@ export default class AbstractButton extends React.Component {
       disabled,
       fullWidth,
       ariaDisabled,
+      tabIndex,
     } = this.props;
     return (
       <button
@@ -95,6 +99,7 @@ export default class AbstractButton extends React.Component {
         onClick={!ariaDisabled ? this.handleOnClick : () => {}}
         disabled={(!ariaDisabled && disabled) || undefined}
         aria-disabled={ariaDisabled || undefined}
+        tabIndex={tabIndex}
       >
         {this.icon()}
         {text}

--- a/src/Button/AbstractButton.js
+++ b/src/Button/AbstractButton.js
@@ -50,7 +50,7 @@ export default class AbstractButton extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
-    tabIndex: "0",
+    tabIndex: undefined,
   };
 
   icon = () => {
@@ -99,7 +99,7 @@ export default class AbstractButton extends React.Component {
         onClick={!ariaDisabled ? this.handleOnClick : () => {}}
         disabled={(!ariaDisabled && disabled) || undefined}
         aria-disabled={ariaDisabled || undefined}
-        tabIndex={tabIndex}
+        {...(tabIndex ? { tabIndex } : undefined)}
       >
         {this.icon()}
         {text}

--- a/src/Button/AbstractButton.test.js
+++ b/src/Button/AbstractButton.test.js
@@ -40,4 +40,17 @@ describe("AbstractButton", () => {
     shallowComponent.find("button").simulate("click");
     expect(mockOnClick.mock.calls.length).toEqual(0);
   });
+  it("renders as expected when tabIndex is passed", async () => {
+    const renderedComponent = renderer
+      .create(
+        <AbstractButton
+          variant="default"
+          text="Test tabIndex"
+          // eslint-disable-next-line jsx-a11y/tabindex-no-positive
+          tabIndex="1"
+        />
+      )
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -46,7 +46,7 @@ export default class Button extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
-    tabIndex: "0",
+    tabIndex: undefined,
   };
 
   render() {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -33,6 +33,8 @@ export default class Button extends React.Component {
     onClick: PropTypes.func,
     /** Makes the button expand to its container's full width. */
     fullWidth: PropTypes.bool,
+    /* Sets the order of which the elements will be focused on. Default value: 0. */
+    tabIndex: PropTypes.string,
   };
 
   static defaultProps = {
@@ -44,6 +46,7 @@ export default class Button extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
+    tabIndex: "0",
   };
 
   render() {
@@ -57,6 +60,7 @@ export default class Button extends React.Component {
       onClick,
       fullWidth,
       ariaDisabled,
+      tabIndex,
     } = this.props;
     return (
       <AbstractButton
@@ -70,6 +74,7 @@ export default class Button extends React.Component {
         ariaDisabled={ariaDisabled}
         onClick={onClick}
         fullWidth={fullWidth}
+        tabIndex={tabIndex}
       />
     );
   }

--- a/src/Button/Button.test.js
+++ b/src/Button/Button.test.js
@@ -77,4 +77,14 @@ describe("Button", () => {
     );
     expect(mountedComponent.find(".lab-btn--block")).toHaveLength(1);
   });
+
+  it("renders as expected when tabIndex is passed", async () => {
+    const renderedComponent = renderer
+      .create(
+        // eslint-disable-next-line jsx-a11y/tabindex-no-positive
+        <Button text="Test tabIndex" fullWidth tabIndex="1" />
+      )
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/src/Button/OutlineButton.js
+++ b/src/Button/OutlineButton.js
@@ -24,6 +24,8 @@ export default class OutlineButton extends React.Component {
     onClick: PropTypes.func,
     /** Makes the button expand to its container's full width. */
     fullWidth: PropTypes.bool,
+    /* Sets the order of which the elements will be focused on. Default value: 0. */
+    tabIndex: PropTypes.string,
   };
 
   static defaultProps = {
@@ -35,6 +37,7 @@ export default class OutlineButton extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
+    tabIndex: "0",
   };
 
   render() {
@@ -48,6 +51,7 @@ export default class OutlineButton extends React.Component {
       onClick,
       fullWidth,
       ariaDisabled,
+      tabIndex,
     } = this.props;
     return (
       <AbstractButton
@@ -61,6 +65,7 @@ export default class OutlineButton extends React.Component {
         ariaDisabled={ariaDisabled}
         onClick={onClick}
         fullWidth={fullWidth}
+        tabIndex={tabIndex}
       />
     );
   }

--- a/src/Button/OutlineButton.js
+++ b/src/Button/OutlineButton.js
@@ -37,7 +37,7 @@ export default class OutlineButton extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
-    tabIndex: "0",
+    tabIndex: undefined,
   };
 
   render() {

--- a/src/Button/OutlineButton.test.js
+++ b/src/Button/OutlineButton.test.js
@@ -86,4 +86,12 @@ describe("OutlineButton", () => {
     );
     expect(mountedComponent.find(".lab-btn--block")).toHaveLength(1);
   });
+
+  it("renders as expected when tabIndex is passed", async () => {
+    const renderedComponent = renderer
+      // eslint-disable-next-line jsx-a11y/tabindex-no-positive
+      .create(<OutlineButton text="Test tabIndex" tabIndex="1" />)
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/src/Button/TextButton.js
+++ b/src/Button/TextButton.js
@@ -24,6 +24,8 @@ export default class TextButton extends React.Component {
     onClick: PropTypes.func,
     /** Makes the button expand to its container's full width. */
     fullWidth: PropTypes.bool,
+     /* Sets the order of which the elements will be focused on. Default value: 0. */
+     tabIndex: PropTypes.string,
   };
 
   static defaultProps = {
@@ -35,6 +37,7 @@ export default class TextButton extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
+    tabIndex: "0",
   };
 
   render() {
@@ -48,6 +51,7 @@ export default class TextButton extends React.Component {
       onClick,
       fullWidth,
       ariaDisabled,
+      tabIndex,
     } = this.props;
     return (
       <AbstractButton
@@ -61,6 +65,7 @@ export default class TextButton extends React.Component {
         ariaDisabled={ariaDisabled}
         onClick={onClick}
         fullWidth={fullWidth}
+        tabIndex={tabIndex}
       />
     );
   }

--- a/src/Button/TextButton.js
+++ b/src/Button/TextButton.js
@@ -24,8 +24,8 @@ export default class TextButton extends React.Component {
     onClick: PropTypes.func,
     /** Makes the button expand to its container's full width. */
     fullWidth: PropTypes.bool,
-     /* Sets the order of which the elements will be focused on. Default value: 0. */
-     tabIndex: PropTypes.string,
+    /* Sets the order of which the elements will be focused on. Default value: 0. */
+    tabIndex: PropTypes.string,
   };
 
   static defaultProps = {
@@ -37,7 +37,7 @@ export default class TextButton extends React.Component {
     ariaDisabled: false,
     onClick: () => {},
     fullWidth: false,
-    tabIndex: "0",
+    tabIndex: undefined,
   };
 
   render() {

--- a/src/Button/TextButton.test.js
+++ b/src/Button/TextButton.test.js
@@ -77,4 +77,12 @@ describe("TextButton", () => {
     );
     expect(mountedComponent.find(".lab-btn--block")).toHaveLength(1);
   });
+
+  it("renders as expected when tabIndex is passed", async () => {
+    const renderedComponent = renderer
+      // eslint-disable-next-line jsx-a11y/tabindex-no-positive
+      .create(<TextButton text="Test tabIndex" tabIndex="1" />)
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/src/Button/__snapshots__/AbstractButton.test.js.snap
+++ b/src/Button/__snapshots__/AbstractButton.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AbstractButton renders as expected when tabIndex is passed 1`] = `
+<button
+  className="lab-btn lab-btn--default lab-btn--normal"
+  onClick={[Function]}
+  tabIndex="1"
+  type="button"
+>
+  
+  Test tabIndex
+</button>
+`;
+
 exports[`AbstractButton renders with base props for default variant 1`] = `
 <button
   className="lab-btn lab-btn--default lab-btn--normal"

--- a/src/Button/__snapshots__/Button.test.js.snap
+++ b/src/Button/__snapshots__/Button.test.js.snap
@@ -58,6 +58,18 @@ exports[`Button renders as expected when passing disabled as true 1`] = `
 </button>
 `;
 
+exports[`Button renders as expected when tabIndex is passed 1`] = `
+<button
+  className="lab-btn lab-btn--default lab-btn--normal lab-btn--block"
+  onClick={[Function]}
+  tabIndex="1"
+  type="button"
+>
+  
+  Test tabIndex
+</button>
+`;
+
 exports[`Button renders with base props 1`] = `
 <button
   className="lab-btn lab-btn--default lab-btn--normal"

--- a/src/Button/__snapshots__/OutlineButton.test.js.snap
+++ b/src/Button/__snapshots__/OutlineButton.test.js.snap
@@ -58,6 +58,18 @@ exports[`OutlineButton renders as expected when passing disabled as true 1`] = `
 </button>
 `;
 
+exports[`OutlineButton renders as expected when tabIndex is passed 1`] = `
+<button
+  className="lab-btn lab-btn--outline lab-btn--normal"
+  onClick={[Function]}
+  tabIndex="1"
+  type="button"
+>
+  
+  Test tabIndex
+</button>
+`;
+
 exports[`OutlineButton renders with base props 1`] = `
 <button
   className="lab-btn lab-btn--outline lab-btn--normal"

--- a/src/Button/__snapshots__/TextButton.test.js.snap
+++ b/src/Button/__snapshots__/TextButton.test.js.snap
@@ -58,6 +58,18 @@ exports[`TextButton renders as expected when passing disabled as true 1`] = `
 </button>
 `;
 
+exports[`TextButton renders as expected when tabIndex is passed 1`] = `
+<button
+  className="lab-btn lab-btn--text lab-btn--normal"
+  onClick={[Function]}
+  tabIndex="1"
+  type="button"
+>
+  
+  Test tabIndex
+</button>
+`;
+
 exports[`TextButton renders with base props 1`] = `
 <button
   className="lab-btn lab-btn--text lab-btn--normal"

--- a/src/Card/FilledCard.js
+++ b/src/Card/FilledCard.js
@@ -27,14 +27,8 @@ export default class FilledCard extends React.Component {
   };
 
   render() {
-    const {
-      children,
-      color,
-      skin,
-      isCompact,
-      isHorizontal,
-      className,
-    } = this.props;
+    const { children, color, skin, isCompact, isHorizontal, className } =
+      this.props;
 
     return (
       <CardContext.Provider value={{ color, skin, cardType: "filled" }}>

--- a/src/Card/OutlineCard.js
+++ b/src/Card/OutlineCard.js
@@ -27,14 +27,8 @@ export default class OutlineCard extends React.Component {
   };
 
   render() {
-    const {
-      children,
-      color,
-      skin,
-      isCompact,
-      isHorizontal,
-      className,
-    } = this.props;
+    const { children, color, skin, isCompact, isHorizontal, className } =
+      this.props;
 
     return (
       <CardContext.Provider value={{ color, skin, cardType: "outline" }}>

--- a/src/Dialog/MessageDialog.js
+++ b/src/Dialog/MessageDialog.js
@@ -111,7 +111,7 @@ export default class MessageDialog extends React.Component {
             <button
               className="lab-dialog__close-button lab-dialog__close-button--message"
               type="button"
-              tabIndex="2"
+              {...(isModal ? { tabIndex: "2" } : undefined)}
               onClick={handleClose}
             >
               <Icon type="remove" className="lab-dialog__close-button-icon" />
@@ -136,7 +136,7 @@ export default class MessageDialog extends React.Component {
                 size="normal"
                 text={outlineButtonProps.text}
                 onClick={outlineButtonProps.onClick}
-                tabIndex="3"
+                {...(isModal ? { tabIndex: "3" } : undefined)}
               />
             ) : undefined}
             <Button
@@ -144,7 +144,7 @@ export default class MessageDialog extends React.Component {
               {...(outlineButtonProps ? undefined : { fullWidth: true })}
               text={buttonProps.text}
               onClick={buttonProps.onClick}
-              tabIndex="1"
+              {...(isModal ? { tabIndex: "1" } : undefined)}
             />
           </div>
         </div>

--- a/src/Dialog/MessageDialog.js
+++ b/src/Dialog/MessageDialog.js
@@ -111,6 +111,7 @@ export default class MessageDialog extends React.Component {
             <button
               className="lab-dialog__close-button lab-dialog__close-button--message"
               type="button"
+              tabIndex="2"
               onClick={handleClose}
             >
               <Icon type="remove" className="lab-dialog__close-button-icon" />
@@ -135,6 +136,7 @@ export default class MessageDialog extends React.Component {
                 size="normal"
                 text={outlineButtonProps.text}
                 onClick={outlineButtonProps.onClick}
+                tabIndex="3"
               />
             ) : undefined}
             <Button
@@ -142,6 +144,7 @@ export default class MessageDialog extends React.Component {
               {...(outlineButtonProps ? undefined : { fullWidth: true })}
               text={buttonProps.text}
               onClick={buttonProps.onClick}
+              tabIndex="1"
             />
           </div>
         </div>

--- a/src/Dialog/StandardDialog.js
+++ b/src/Dialog/StandardDialog.js
@@ -106,7 +106,7 @@ export default class StandardDialog extends React.Component {
               className="lab-dialog__close-button"
               type="button"
               onClick={handleClose}
-              tabIndex="2"
+              {...(isModal ? { tabIndex: "2" } : undefined)}
             >
               <Icon type="remove" className="lab-dialog__close-button-icon" />
             </button>
@@ -120,14 +120,14 @@ export default class StandardDialog extends React.Component {
                 size="normal"
                 text={outlineButtonProps.text}
                 onClick={outlineButtonProps.onClick}
-                tabIndex="3"
+                {...(isModal ? { tabIndex: "3" } : undefined)}
               />
             ) : undefined}
             <Button
               size="normal"
               text={buttonProps.text}
               onClick={buttonProps.onClick}
-              tabIndex="1"
+              {...(isModal ? { tabIndex: "1" } : undefined)}
             />
           </div>
         </div>

--- a/src/Dialog/StandardDialog.js
+++ b/src/Dialog/StandardDialog.js
@@ -106,6 +106,7 @@ export default class StandardDialog extends React.Component {
               className="lab-dialog__close-button"
               type="button"
               onClick={handleClose}
+              tabIndex="2"
             >
               <Icon type="remove" className="lab-dialog__close-button-icon" />
             </button>
@@ -119,12 +120,14 @@ export default class StandardDialog extends React.Component {
                 size="normal"
                 text={outlineButtonProps.text}
                 onClick={outlineButtonProps.onClick}
+                tabIndex="3"
               />
             ) : undefined}
             <Button
               size="normal"
               text={buttonProps.text}
               onClick={buttonProps.onClick}
+              tabIndex="1"
             />
           </div>
         </div>

--- a/src/Tags/TogglableTag.js
+++ b/src/Tags/TogglableTag.js
@@ -48,15 +48,8 @@ export default class TogglableTag extends React.Component {
   };
 
   render() {
-    const {
-      text,
-      color,
-      isOutline,
-      disabled,
-      ariaDisabled,
-      isOn,
-      onClick,
-    } = this.props;
+    const { text, color, isOutline, disabled, ariaDisabled, isOn, onClick } =
+      this.props;
     return (
       <AbstractTag
         className={`lab-tag--togglable${isOn ? " lab-tag--selected" : ""}`}


### PR DESCRIPTION
**Link to task:**
https://labcodes.atlassian.net/browse/CSYS-296

**Description of your solution:**
Today, when a dialog is open, the close button is the first button to be focused on. This PR aims to have the main button on the dialog as the first button to gain focus, once the dialog opens. The new order of focus is: main button, close button and then optional button.