### PR TITLE
[DEPRECATED]: Division outside of calc() 

### DIFF
--- a/scss/variables/_borders.scss
+++ b/scss/variables/_borders.scss
@@ -4,7 +4,7 @@ $border-4: 4px solid;
 $border-6: 6px solid;
 
 // Radius
-$radius-05: ($baseline / 2); //2px
+$radius-05: calc($baseline / 2); //2px
 $radius-1: $baseline; //4px
 $radius-2: (2 * $baseline); //8px
 $radius-3: (3 * $baseline); //12px


### PR DESCRIPTION
**Context
Removed deprecation:
- [Division outside of calc()](https://sass-lang.com/documentation/breaking-changes/slash-div)

**Description**
This PR remove deprecation warning of divsion ``` ($baseline / 2) ``` outside of calc()

Before ``` ($baseline / 2) ```
After ``` calc($baseline / 2) ```