### PR TITLE
[CSYS-302] Remove fixed width for Search components

### DIFF
--- a/scss/components/_lab-searchinput.scss
+++ b/scss/components/_lab-searchinput.scss
@@ -58,11 +58,11 @@ $remove-icon-focus: map-get($search-theme, "30");
 .lab-standard-search {
   @include remove-delete-icon-search-input;
   position: relative;
-  z-index: 99;
-  width: 320px;
+  width: 100%;
   margin-top: $spacing-3;
   box-sizing: border-box;
   border-radius: $radius-1;
+  display: block;
 
   .lab-search__remove-icon {
     margin-right: $spacing-13;
@@ -156,10 +156,11 @@ $remove-icon-focus: map-get($search-theme, "30");
 .lab-inline-search {
   @include remove-delete-icon-search-input;
   position: relative;
-  width: 320px;
+  width: 100%;
   margin-top: $spacing-3;
   box-sizing: border-box;
   border-radius: $radius-1;
+  display: block;
 
   .lab-search__field {
     padding-left: $spacing-13;


### PR DESCRIPTION

### Remove fixed width for Search components

**Link to task:** [Card from Jira](https://labcodes.atlassian.net/jira/software/c/projects/CSYS/boards/63?modal=detail&selectedIssue=CSYS-302)

**Staging app:** https://your-branch--labstorybook-master.netlify.app/

**How to test:** After running the project' Storybook locally, go the sidebar and click at *Search* section as shown below:
![image](https://user-images.githubusercontent.com/12106738/164081850-b90a0f1a-1b19-456f-b3a5-7cb1380deb53.png)

Then alter your browser's window and verify if the components' widths change proportionally.

**Description of your solution:** Adjusting the AbstractSearch component stylesheet to change its width proportionally.

**Screenshots (when applicable):**

https://user-images.githubusercontent.com/12106738/164082787-5fe07ccc-bffc-4eac-afcd-9c657b73b931.mp4


