### PR TITLE
CSYS-306: React 18 keyboard interactions and Render Dropdown Options

### DIFF
--- a/src/Dropdown/AbstractDropdown.js
+++ b/src/Dropdown/AbstractDropdown.js
@@ -321,9 +321,12 @@ export default class AbstractDropdown extends Component {
           id={`menu--${id}`}
         >
           {React.Children.map(children, (child, index) => {
-            const isDropdownSectionTitle = child.type === DropdownSectionTitle;
+            const isDropdownSectionTitle =
+              child.type === DropdownSectionTitle ||
+              child.type.name === "DropdownSectionTitle";
             // change it to || child.type == OptionItem...
-            const isDropdownItem = child.type === TagItem;
+            const isDropdownItem =
+              child.type === TagItem || child.type.name === "TagItem";
 
             if (isDropdownSectionTitle)
               return <child.type {...child.props} color={color} />;

--- a/src/Dropdown/AbstractDropdown.js
+++ b/src/Dropdown/AbstractDropdown.js
@@ -297,7 +297,7 @@ export default class AbstractDropdown extends Component {
 
     const trigger = {
       button: <Button text={displayText} />,
-      tag: <TagDropdownTrigger text={displayText} color={color} />,
+      tag: <TagDropdownTrigger text={displayText} color={color} isOutline />,
     };
 
     const renderTrigger = trigger[dropdownType];

--- a/src/Dropdown/DropdownOption.js
+++ b/src/Dropdown/DropdownOption.js
@@ -20,13 +20,16 @@ export default class DropdownOption extends Component {
     /** This is the ref of the option */
     optionRef: PropTypes.shape({
       current: PropTypes.instanceOf(HTMLButtonElement),
-    }).isRequired,
+    }),
   };
 
   static defaultProps = {
     // functions
     handleSelectDropdownOption: () => {},
     setDefaultOption: () => {},
+    optionRef: {
+      current: null,
+    },
   };
 
   constructor(props) {

--- a/src/Dropdown/DropdownOption.js
+++ b/src/Dropdown/DropdownOption.js
@@ -9,9 +9,7 @@ export default class DropdownOption extends Component {
     setDefaultOption: PropTypes.func,
     /** This function fires when keyboard interactions are detected. */
     handleKeyDown: PropTypes.func.isRequired,
-    /** This function sets the ref of the option if this is valid (meaning TagItem does not have the "disabled" prop). */
-    setRef: PropTypes.func.isRequired,
-    /** TThis prop is used to set if an option is currently selected */
+    /** This prop is used to set if an option is currently selected */
     selectedOption: PropTypes.object.isRequired,
     /** This children prop is the TagItem */
     children: PropTypes.node.isRequired,
@@ -19,6 +17,10 @@ export default class DropdownOption extends Component {
     index: PropTypes.number.isRequired,
     /** This is the unique id of the option */
     id: PropTypes.string.isRequired,
+    /** This is the ref of the option */
+    optionRef: PropTypes.shape({
+      current: PropTypes.instanceOf(HTMLButtonElement),
+    }).isRequired,
   };
 
   static defaultProps = {
@@ -30,15 +32,13 @@ export default class DropdownOption extends Component {
   constructor(props) {
     super(props);
 
-    const { setRef, children } = this.props;
+    const { children, optionRef } = this.props;
     const isNotDisabled = !children.props.disabled;
-    this.ref = React.createRef();
-    if (isNotDisabled) setRef(this.ref);
+    if (isNotDisabled) this.ref = optionRef;
   }
 
   componentDidMount() {
     const { setDefault } = this;
-
     setDefault();
   }
 
@@ -85,6 +85,7 @@ export default class DropdownOption extends Component {
     const { text, value, disabled } = children.props;
     const isSelected = selectedOption.ref === this.ref;
     const skin = isSelected ? "vivid" : "pale";
+    const ref = disabled ? null : this.ref;
 
     return (
       <div
@@ -108,7 +109,7 @@ export default class DropdownOption extends Component {
           onKeyDown={handleKeyDown}
           aria-disabled={disabled}
           id={`option-${index}--menu--${id}`}
-          ref={disabled ? null : this.ref}
+          ref={ref}
         >
           {text}
         </button>

--- a/src/Dropdown/__snapshots__/AbstractDropdown.test.js.snap
+++ b/src/Dropdown/__snapshots__/AbstractDropdown.test.js.snap
@@ -18,7 +18,7 @@ exports[`AbstractDropdown renders as expected when passing color as teal 1`] = `
       Click me
     </button>
     <span
-      className="lab-tag lab-tag--dropdown lab-tag--teal-pale"
+      className="lab-tag lab-tag--dropdown lab-tag--outline lab-tag--teal-pale"
       onClick={[Function]}
       onKeyPress={[Function]}
       role="button"
@@ -149,7 +149,7 @@ exports[`AbstractDropdown renders with base props 1`] = `
       Click me
     </button>
     <span
-      className="lab-tag lab-tag--dropdown lab-tag--teal-pale"
+      className="lab-tag lab-tag--dropdown lab-tag--outline lab-tag--teal-pale"
       onClick={[Function]}
       onKeyPress={[Function]}
       role="button"

--- a/src/Dropdown/__snapshots__/TagDropdown.test.js.snap
+++ b/src/Dropdown/__snapshots__/TagDropdown.test.js.snap
@@ -18,7 +18,7 @@ exports[`TagDropdown renders as expected when passing color as teal 1`] = `
       Click me
     </button>
     <span
-      className="lab-tag lab-tag--dropdown lab-tag--teal-pale"
+      className="lab-tag lab-tag--dropdown lab-tag--outline lab-tag--teal-pale"
       onClick={[Function]}
       onKeyPress={[Function]}
       role="button"
@@ -149,7 +149,7 @@ exports[`TagDropdown renders with base props 1`] = `
       Click me
     </button>
     <span
-      className="lab-tag lab-tag--dropdown lab-tag--teal-pale"
+      className="lab-tag lab-tag--dropdown lab-tag--outline lab-tag--teal-pale"
       onClick={[Function]}
       onKeyPress={[Function]}
       role="button"


### PR DESCRIPTION
**Description:**
Esse PR muda a forma que definimos as `refs` das opções do `TagDropdown`. Também mudamos a forma que filtramos as children do `TagDropdown`. Ele resolve os bugs [CSYS-306](https://labcodes.atlassian.net/browse/CSYS-306) e [CSYS-307](https://labcodes.atlassian.net/browse/CSYS-307)

**Context:**
Antes estávamos definindo a ref das opções usando `React State`, isso causava problemas no React v18 e no Vite (com React v18). Agora estamos definindo isso via referencia de objeto. O problema estava ocorrendo porque o componente era renderizado varias vezes e criava refs nulas no optionsRefList state

`optionsRefList` => optionsRefList is a Array of refs to valid options. It means if you pass disabled prop to a DropdownOption, its ref will not be in this array.
`generateOptionsRefs` => This function is used to generate refs to valid options. It maps the option index to its ref.



Fluxo: 
  - Criamos um objeto para mapear a ref ao index da opção.
  - Passamos essa ref para o componente DropdownOption por meio da prop optionRef 
  - Passamos a optionRef para o this.ref do componente DropdownOption
  - No componente, temos acesso a uma lista de referências para lidar com os eventos do keyboard


**Screenshots**

https://user-images.githubusercontent.com/42525687/165522088-5f365929-63d2-4979-ad9a-34aee9488f52.mp4
React 18 running on vite

https://user-images.githubusercontent.com/42525687/165523112-9f2a1539-3d0b-4447-8c11-a512914b9fab.mp4
React 18 running on create-react-app

