### PR TITLE
[CSYS-314] Migrate Dialog to function component

### DIFF
--- a/src/Dialog/DialogWrapper.js
+++ b/src/Dialog/DialogWrapper.js
@@ -2,80 +2,60 @@ import React from "react";
 import PropTypes from "prop-types";
 import FocusTrap from "focus-trap-react";
 
-export default class DialogWrapper extends React.Component {
-  static propTypes = {
-    handleClose: PropTypes.func.isRequired,
-    isOpen: PropTypes.bool.isRequired,
-    isModal: PropTypes.bool.isRequired,
-    children: PropTypes.node.isRequired,
-    isMessageDialog: PropTypes.bool,
-    isLarge: PropTypes.bool,
-  };
+/**
+ *
+ * @param isOpen Toggles overflow based on is open state. It changes the state shouldToggleOverflow
+ * @param isModal Toggles overflow based on is a modal state. It changes the state shouldToggleOverflow
+ * @param handleClose This function prop is called on a close button or outside click event
+ * @param isLarge Toggles .lab-dialog--large classname to increase Dialog width
+ * @param isMessageDialog Toggles .lab-dialog--large classname to increase Dialog width
+ * @param children Components that will be rendered in the DialogWrapper (MessageDialog, StandardDialog)
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export default function DialogWrapper({
+  isOpen,
+  isModal,
+  handleClose,
+  isLarge,
+  isMessageDialog,
+  children,
+}) {
+  const deviceIsMobile = window.outerWidth <= 768;
+  const [shouldToggleOverflow, setShouldToggleOverflow] = React.useState(
+    isOpen && (isModal || deviceIsMobile)
+  );
 
-  static defaultProps = {
-    isMessageDialog: undefined,
-    isLarge: undefined,
-  };
-
-  constructor(props) {
-    super(props);
-    const { isOpen, isModal } = props;
+  const handleResize = () => {
     const deviceIsMobile = window.outerWidth <= 768;
-    this.state = {
-      shouldToggleOverflow: isOpen && (isModal || deviceIsMobile),
-    };
-  }
+    setShouldToggleOverflow(isOpen && (isModal || deviceIsMobile));
+  };
 
-  componentDidMount() {
-    window.addEventListener("resize", this.handleResize);
-    this.handleOverflow();
-  }
-
-  componentDidUpdate() {
-    this.handleOverflow();
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("resize", this.handleResize, false);
-    document.body.style.overflow = "unset";
-  }
-
-  handleOverflow = () => {
-    const { shouldToggleOverflow } = this.state;
+  const handleOverflow = () => {
     document.body.style.overflow = shouldToggleOverflow ? "hidden" : "unset";
   };
 
-  handleResize = () => {
-    const { isOpen, isModal } = this.props;
-    const deviceIsMobile = window.outerWidth <= 768;
-    this.setState({
-      shouldToggleOverflow: isOpen && (isModal || deviceIsMobile),
-    });
-  };
+  React.useEffect(() => {
+    window.addEventListener("resize", handleResize);
 
-  render() {
-    const { handleClose, isLarge, isMessageDialog, children } = this.props;
-    const { shouldToggleOverflow } = this.state;
-    return shouldToggleOverflow ? (
-      <React.Fragment>
-        <div
-          className="lab-dialog-overlay"
-          onClick={handleClose}
-          role="presentation"
-        />
-        <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
-          <div
-            className={`lab-dialog${
-              isMessageDialog ? " lab-dialog--message" : " lab-dialog--standard"
-            }
-            ${isLarge ? ` lab-dialog--large` : ""}`}
-          >
-            {children}
-          </div>
-        </FocusTrap>
-      </React.Fragment>
-    ) : (
-      <React.Fragment>
+    return () => {
+      window.removeEventListener("resize", handleResize, false);
+      document.body.style.overflow = "unset";
+    };
+  }, []);
+
+  React.useEffect(() => {
+    handleOverflow();
+  }, [shouldToggleOverflow, isOpen, isModal, deviceIsMobile]);
+
+  return shouldToggleOverflow ? (
+    <React.Fragment>
+      <div
+        className="lab-dialog-overlay"
+        onClick={handleClose}
+        role="presentation"
+      />
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
         <div
           className={`lab-dialog${
             isMessageDialog ? " lab-dialog--message" : " lab-dialog--standard"
@@ -84,7 +64,38 @@ export default class DialogWrapper extends React.Component {
         >
           {children}
         </div>
-      </React.Fragment>
-    );
-  }
+      </FocusTrap>
+    </React.Fragment>
+  ) : (
+    <React.Fragment>
+      <div
+        className={`lab-dialog${
+          isMessageDialog ? " lab-dialog--message" : " lab-dialog--standard"
+        }
+            ${isLarge ? ` lab-dialog--large` : ""}`}
+      >
+        {children}
+      </div>
+    </React.Fragment>
+  );
 }
+
+DialogWrapper.propTypes = {
+  /** This function prop is called on a close button or outside click event */
+  handleClose: PropTypes.func.isRequired,
+  /** Toggles overflow based on is open state. It changes the state shouldToggleOverflow . */
+  isOpen: PropTypes.bool.isRequired,
+  /** Toggles overflow based on is a modal state. It changes the state shouldToggleOverflow . */
+  isModal: PropTypes.bool.isRequired,
+  /** Components that will be rendered in the DialogWrapper (MessageDialog, StandardDialog) */
+  children: PropTypes.node.isRequired,
+  /** Toggles .lab-dialog--message classname */
+  isMessageDialog: PropTypes.bool,
+  /** Toggles .lab-dialog--large classname to increase Dialog width */
+  isLarge: PropTypes.bool,
+};
+
+DialogWrapper.defaultProps = {
+  isMessageDialog: undefined,
+  isLarge: undefined,
+};

--- a/src/Dialog/DialogWrapper.test.js
+++ b/src/Dialog/DialogWrapper.test.js
@@ -1,0 +1,115 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import DialogWrapper from "./DialogWrapper";
+
+describe("DialogWrapper", () => {
+  it("renders with base props", () => {
+    const handleClose = jest.fn();
+    const isOpen = false;
+    const isModal = false;
+    const isLarge = false;
+
+    const Component = (
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+        isLarge={isLarge}
+        isMessageDialog
+      >
+        <div />
+      </DialogWrapper>
+    );
+
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isOpen false", () => {
+    const handleClose = jest.fn();
+    const isOpen = false;
+    const isModal = true;
+    const isLarge = true;
+    const Component = (
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+        isLarge={isLarge}
+        isMessageDialog
+      >
+        <div />
+      </DialogWrapper>
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isModal false", () => {
+    const handleClose = jest.fn();
+    const isOpen = true;
+    const isModal = false;
+    const isLarge = true;
+
+    const Component = (
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+        isLarge={isLarge}
+        isMessageDialog
+      >
+        <div />
+      </DialogWrapper>
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+  it("test with isMessageDialog false", () => {
+    const handleClose = jest.fn();
+    const isOpen = true;
+    const isModal = true;
+    const isLarge = true;
+    const isMessageDialog = false;
+
+    const Component = (
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+        isLarge={isLarge}
+        isMessageDialog={isMessageDialog}
+      >
+        <div />
+      </DialogWrapper>
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isLarge false", () => {
+    const handleClose = jest.fn();
+    const isOpen = true;
+    const isModal = true;
+    const isLarge = false;
+    const Component = (
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+        isLarge={isLarge}
+        isMessageDialog
+      >
+        <div />
+      </DialogWrapper>
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+});

--- a/src/Dialog/MessageDialog.js
+++ b/src/Dialog/MessageDialog.js
@@ -6,149 +6,136 @@ import DialogWrapper from "./DialogWrapper";
 import { Button, OutlineButton } from "../Button";
 import { ICON_TYPES } from "../constants";
 
-export default class MessageDialog extends React.Component {
-  static propTypes = {
-    icon: PropTypes.oneOf(ICON_TYPES).isRequired,
-    title: PropTypes.string.isRequired,
-    content: PropTypes.string.isRequired,
-    buttonProps: PropTypes.exact({
-      text: PropTypes.string.isRequired,
-      onClick: PropTypes.func.isRequired,
-    }).isRequired,
-    outlineButtonProps: PropTypes.exact({
-      text: PropTypes.string.isRequired,
-      onClick: PropTypes.func.isRequired,
-    }),
-    isLarge: PropTypes.bool,
-    handleClose: PropTypes.func,
-    isOpen: PropTypes.bool,
-    isModal: PropTypes.bool,
-  };
+export default function MessageDialog({
+  icon,
+  title,
+  content,
+  buttonProps,
+  outlineButtonProps,
+  isLarge,
+  isOpen,
+  handleClose,
+  isModal,
+}) {
+  const [swipeStartYCoordinate, setSwipeStartYCoordinate] =
+    React.useState(undefined);
 
-  static defaultProps = {
-    outlineButtonProps: undefined,
-    isLarge: false,
-    handleClose: () => {},
-    isOpen: false,
-    isModal: false,
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      swipeStartYCoordinate: undefined,
-    };
-  }
-
-  componentDidMount() {
-    document.addEventListener("keydown", this.handleKeyDown, false);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this.handleKeyDown, false);
-  }
-
-  handleKeyDown = (event) => {
-    const { handleClose } = this.props;
+  const handleKeyDown = (event) => {
     if (event.keyCode === 27) {
       handleClose();
     }
   };
 
-  handleTouchStart = (event) => {
-    this.setState({ swipeStartYCoordinate: event.changedTouches[0].screenY });
+  const handleTouchStart = (event) => {
+    setSwipeStartYCoordinate(event.changedTouches[0].screenY);
   };
 
-  handleTouchEnd = (event) => {
-    const { handleClose } = this.props;
-    const { swipeStartYCoordinate } = this.state;
-
+  const handleTouchEnd = (event) => {
     if (event.changedTouches[0].screenY - swipeStartYCoordinate >= 75) {
-      this.setState({ swipeStartYCoordinate: undefined }, () => handleClose());
+      setSwipeStartYCoordinate(undefined);
+      handleClose();
     } else {
-      this.setState({ swipeStartYCoordinate: undefined });
+      setSwipeStartYCoordinate(undefined);
     }
   };
 
-  render() {
-    const {
-      icon,
-      title,
-      content,
-      buttonProps,
-      outlineButtonProps,
-      isLarge,
-      isOpen,
-      handleClose,
-      isModal,
-    } = this.props;
+  React.useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown, false);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, false);
+    };
+  }, []);
 
-    if (!isOpen) return null;
-    return (
-      <DialogWrapper
-        handleClose={handleClose}
-        isOpen={isOpen}
-        isModal={isModal}
-        isLarge={isLarge}
-        isMessageDialog
+  if (!isOpen) return null;
+  return (
+    <DialogWrapper
+      handleClose={handleClose}
+      isOpen={isOpen}
+      isModal={isModal}
+      isLarge={isLarge}
+      isMessageDialog
+    >
+      <div
+        className="lab-dialog__content lab-dialog__content--message"
+        role="dialog"
+        aria-modal="true"
       >
-        <div
-          className="lab-dialog__content lab-dialog__content--message"
-          role="dialog"
-          aria-modal="true"
+        <button
+          type="button"
+          className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
+          onClick={handleClose}
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
         >
+          <Icon type="collapse-open" />
+        </button>
+        <div className="lab-dialog__header lab-dialog__header--message">
           <button
+            className="lab-dialog__close-button"
             type="button"
-            className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
+            {...(isModal ? { tabIndex: "2" } : undefined)}
             onClick={handleClose}
-            onTouchStart={this.handleTouchStart}
-            onTouchEnd={this.handleTouchEnd}
           >
-            <Icon type="collapse-open" />
+            <Icon type="remove" className="lab-dialog__close-button-icon" />
           </button>
-          <div className="lab-dialog__header lab-dialog__header--message">
-            <button
-              className="lab-dialog__close-button"
-              type="button"
-              {...(isModal ? { tabIndex: "2" } : undefined)}
-              onClick={handleClose}
-            >
-              <Icon type="remove" className="lab-dialog__close-button-icon" />
-            </button>
-          </div>
-
-          <div className="lab-dialog__icon-wrapper">
-            <Icon type={icon} className="lab-dialog__icon" />
-          </div>
-
-          <div className="lab-dialog__title lab-dialog__title--message">
-            {title}
-          </div>
-
-          <div className="lab-dialog__body lab-dialog__body--message">
-            {content}
-          </div>
-
-          <div className="lab-dialog__footer lab-dialog__footer--message">
-            {outlineButtonProps ? (
-              <OutlineButton
-                size="normal"
-                text={outlineButtonProps.text}
-                onClick={outlineButtonProps.onClick}
-                {...(isModal ? { tabIndex: "3" } : undefined)}
-              />
-            ) : undefined}
-            <Button
-              size="normal"
-              {...(outlineButtonProps ? undefined : { fullWidth: true })}
-              text={buttonProps.text}
-              onClick={buttonProps.onClick}
-              {...(isModal ? { tabIndex: "1" } : undefined)}
-            />
-          </div>
         </div>
-      </DialogWrapper>
-    );
-  }
+
+        <div className="lab-dialog__icon-wrapper">
+          <Icon type={icon} className="lab-dialog__icon" />
+        </div>
+
+        <div className="lab-dialog__title lab-dialog__title--message">
+          {title}
+        </div>
+
+        <div className="lab-dialog__body lab-dialog__body--message">
+          {content}
+        </div>
+
+        <div className="lab-dialog__footer lab-dialog__footer--message">
+          {outlineButtonProps ? (
+            <OutlineButton
+              size="normal"
+              text={outlineButtonProps.text}
+              onClick={outlineButtonProps.onClick}
+              {...(isModal ? { tabIndex: "3" } : undefined)}
+            />
+          ) : undefined}
+          <Button
+            size="normal"
+            {...(outlineButtonProps ? undefined : { fullWidth: true })}
+            text={buttonProps.text}
+            onClick={buttonProps.onClick}
+            {...(isModal ? { tabIndex: "1" } : undefined)}
+          />
+        </div>
+      </div>
+    </DialogWrapper>
+  );
 }
+
+MessageDialog.propTypes = {
+  icon: PropTypes.oneOf(ICON_TYPES).isRequired,
+  title: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  buttonProps: PropTypes.exact({
+    text: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+  }).isRequired,
+  outlineButtonProps: PropTypes.exact({
+    text: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+  }),
+  isLarge: PropTypes.bool,
+  handleClose: PropTypes.func,
+  isOpen: PropTypes.bool,
+  isModal: PropTypes.bool,
+};
+
+MessageDialog.defaultProps = {
+  outlineButtonProps: undefined,
+  isLarge: false,
+  handleClose: () => {},
+  isOpen: false,
+  isModal: false,
+};

--- a/src/Dialog/MessageDialog.test.js
+++ b/src/Dialog/MessageDialog.test.js
@@ -1,0 +1,127 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { mount } from "enzyme";
+
+import { MessageDialog } from "./index";
+
+const args = {
+  title: "Sample Message Dialog",
+  icon: "star",
+  content:
+    "This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.",
+  buttonProps: {
+    text: "Required button",
+    onClick: () => alert("Required button clicked"),
+  },
+  outlineButtonProps: {
+    text: "Optional button",
+    onClick: () => alert("Optional button clicked"),
+  },
+  isModal: false,
+  isOpen: false,
+  handleCLose: jest.fn(),
+  isMessageDialog: true,
+};
+
+describe("MessageDialog", () => {
+  it("renders with base props", () => {
+    const Component = <MessageDialog {...args} />;
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isOpen false", () => {
+    const Component = (
+      <MessageDialog {...args} isModal isLarge isOpen={false} />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isModal false", () => {
+    const Component = (
+      <MessageDialog {...args} isModal={false} isLarge isOpen />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isLarge false", () => {
+    const Component = (
+      <MessageDialog {...args} isModal isOpen isLarge={false} />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it(`checks if isOpen false sets body overflow to `, () => {
+    let isOpen = false;
+    const handleClose = () => {
+      isOpen = false;
+    };
+
+    const Component = (
+      <MessageDialog
+        {...args}
+        isModal
+        isOpen={isOpen}
+        handleClose={handleClose}
+      />
+    );
+
+    const renderedComponent = renderer.create(Component).toJSON();
+    const wrapper = mount(Component);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
+    expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+  it("checks if isOpen true sets body overflow to hidden", () => {
+    let isOpen = true;
+    const handleClose = () => {
+      isOpen = false;
+    };
+    const Component = (
+      <MessageDialog
+        {...args}
+        isModal
+        isOpen={isOpen}
+        handleClose={handleClose}
+      />
+    );
+
+    const renderedComponent = renderer.create(Component).toJSON();
+    const wrapper = mount(Component);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
+    expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+  it("toggle isOpen", () => {
+    const handleClose = () => {};
+    const Component = (
+      <MessageDialog {...args} isModal isOpen handleClose={handleClose} />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+    const wrapper = mount(Component);
+
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
+    expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
+
+    wrapper.setProps({ isOpen: false });
+
+    expect(document.body.style.overflow).toBe("unset");
+    expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
+    expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+});

--- a/src/Dialog/MessageDialog.test.js
+++ b/src/Dialog/MessageDialog.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";

--- a/src/Dialog/MessageDialog.test.js
+++ b/src/Dialog/MessageDialog.test.js
@@ -24,104 +24,128 @@ const args = {
 };
 
 describe("MessageDialog", () => {
-  it("renders with base props", () => {
-    const Component = <MessageDialog {...args} />;
-    const renderedComponent = renderer.create(Component).toJSON();
-
-    expect(renderedComponent).toMatchSnapshot();
+  afterEach(() => {
+    /* reset html tag after each test case */
+    document.getElementsByTagName("html")[0].innerHTML = "";
   });
 
-  it("test with isOpen false", () => {
+  it("rendering with base props", () => {
+    expect(document.body.style.overflow).toBe("");
+
+    const Component = <MessageDialog {...args} />;
+    const renderedComponent = renderer.create(Component);
+
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+  });
+
+  it("rendering with isOpen false", () => {
+    expect(document.body.style.overflow).toBe("");
+
     const Component = (
       <MessageDialog {...args} isModal isLarge isOpen={false} />
     );
-    const renderedComponent = renderer.create(Component).toJSON();
+    const renderedComponent = renderer.create(Component);
 
-    expect(renderedComponent).toMatchSnapshot();
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+
+    expect(document.body.style.overflow).toBe("");
   });
 
-  it("test with isModal false", () => {
+  it("rendering with isModal false", () => {
+    expect(document.body.style.overflow).toBe("");
+
     const Component = (
       <MessageDialog {...args} isModal={false} isLarge isOpen />
     );
-    const renderedComponent = renderer.create(Component).toJSON();
+    const renderedComponent = renderer.create(Component);
 
-    expect(renderedComponent).toMatchSnapshot();
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
 
-  it("test with isLarge false", () => {
+  it("rendering with isLarge false", () => {
+    expect(document.body.style.overflow).toBe("");
+
     const Component = (
       <MessageDialog {...args} isModal isOpen isLarge={false} />
     );
-    const renderedComponent = renderer.create(Component).toJSON();
+    const renderedComponent = renderer.create(Component);
 
-    expect(renderedComponent).toMatchSnapshot();
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
 
-  it(`checks if isOpen false sets body overflow to `, () => {
-    let isOpen = false;
-    const handleClose = () => {
-      isOpen = false;
-    };
+  it(`rendering if isOpen false sets body overflow to empty`, () => {
+    expect(document.body.style.overflow).toBe("");
 
-    const Component = (
+    const wrapper = mount(
       <MessageDialog
         {...args}
-        isModal
-        isOpen={isOpen}
-        handleClose={handleClose}
+        isModal // true
+        isOpen={false}
       />
     );
 
-    const renderedComponent = renderer.create(Component).toJSON();
-    const wrapper = mount(Component);
-    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.overflow).toBe("");
 
     expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
     expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
 
-    expect(renderedComponent).toMatchSnapshot();
+    wrapper.unmount();
   });
-  it("checks if isOpen true sets body overflow to hidden", () => {
-    let isOpen = true;
-    const handleClose = () => {
-      isOpen = false;
-    };
-    const Component = (
+  it("checks if isOpen and isModal true sets body overflow to hidden", () => {
+    expect(document.body.style.overflow).toBe("");
+
+    const wrapper = mount(
       <MessageDialog
         {...args}
-        isModal
-        isOpen={isOpen}
-        handleClose={handleClose}
+        isModal // true
+        isOpen // true
       />
     );
 
-    const renderedComponent = renderer.create(Component).toJSON();
-    const wrapper = mount(Component);
     expect(document.body.style.overflow).toBe("hidden");
+
     expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
     expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
 
-    expect(renderedComponent).toMatchSnapshot();
+    wrapper.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
   it("toggle isOpen", () => {
-    const handleClose = () => {};
-    const Component = (
-      <MessageDialog {...args} isModal isOpen handleClose={handleClose} />
-    );
-    const renderedComponent = renderer.create(Component).toJSON();
-    const wrapper = mount(Component);
+    expect(document.body.style.overflow).toBe("");
+
+    const wrapper = mount(<MessageDialog {...args} isModal isOpen />);
 
     expect(document.body.style.overflow).toBe("hidden");
+
     expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
     expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
 
     wrapper.setProps({ isOpen: false });
 
     expect(document.body.style.overflow).toBe("unset");
+
     expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
     expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
 
-    expect(renderedComponent).toMatchSnapshot();
+    wrapper.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
 });

--- a/src/Dialog/StandardDialog.js
+++ b/src/Dialog/StandardDialog.js
@@ -5,133 +5,120 @@ import Icon from "../Icon";
 import { Button, OutlineButton } from "../Button";
 import DialogWrapper from "./DialogWrapper";
 
-export default class StandardDialog extends React.Component {
-  static propTypes = {
-    title: PropTypes.string.isRequired,
-    content: PropTypes.string.isRequired,
-    buttonProps: PropTypes.exact({
-      text: PropTypes.string.isRequired,
-      onClick: PropTypes.func.isRequired,
-    }).isRequired,
-    outlineButtonProps: PropTypes.exact({
-      text: PropTypes.string.isRequired,
-      onClick: PropTypes.func.isRequired,
-    }),
-    isLarge: PropTypes.bool,
-    handleClose: PropTypes.func,
-    isOpen: PropTypes.bool,
-    isModal: PropTypes.bool,
-  };
+export default function StandardDialog({
+  title,
+  content,
+  buttonProps,
+  outlineButtonProps,
+  isLarge,
+  isOpen,
+  isModal,
+  handleClose,
+}) {
+  const [swipeStartYCoordinate, setSwipeStartYCoordinate] =
+    React.useState(undefined);
 
-  static defaultProps = {
-    outlineButtonProps: undefined,
-    isLarge: false,
-    handleClose: () => {},
-    isOpen: false,
-    isModal: false,
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      swipeStartYCoordinate: undefined,
-    };
-  }
-
-  componentDidMount() {
-    document.addEventListener("keydown", this.handleKeyDown, false);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this.handleKeyDown, false);
-  }
-
-  handleKeyDown = (event) => {
-    const { handleClose } = this.props;
+  const handleKeyDown = (event) => {
     if (event.keyCode === 27) {
       handleClose();
     }
   };
 
-  handleTouchStart = (event) => {
-    this.setState({ swipeStartYCoordinate: event.changedTouches[0].screenY });
+  const handleTouchStart = (event) => {
+    setSwipeStartYCoordinate(event.changedTouches[0].screenY);
   };
 
-  handleTouchEnd = (event) => {
-    const { handleClose } = this.props;
-    const { swipeStartYCoordinate } = this.state;
-
+  const handleTouchEnd = (event) => {
     if (event.changedTouches[0].screenY - swipeStartYCoordinate >= 75) {
-      this.setState({ swipeStartYCoordinate: undefined }, () => handleClose());
+      setSwipeStartYCoordinate(undefined);
+      handleClose();
     } else {
-      this.setState({ swipeStartYCoordinate: undefined });
+      setSwipeStartYCoordinate(undefined);
     }
   };
 
-  render() {
-    const {
-      title,
-      content,
-      buttonProps,
-      outlineButtonProps,
-      isLarge,
-      isOpen,
-      isModal,
-      handleClose,
-    } = this.props;
+  React.useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown, false);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, false);
+    };
+  }, []);
 
-    if (!isOpen) return null;
-    return (
-      <DialogWrapper
-        handleClose={handleClose}
-        isOpen={isOpen}
-        isModal={isModal}
-        isLarge={isLarge}
-      >
-        <div className="lab-dialog__content" role="dialog" aria-modal="true">
+  if (!isOpen) return null;
+  return (
+    <DialogWrapper
+      handleClose={handleClose}
+      isOpen={isOpen}
+      isModal={isModal}
+      isLarge={isLarge}
+    >
+      <div className="lab-dialog__content" role="dialog" aria-modal="true">
+        <button
+          type="button"
+          className="lab-dialog__mobile-close-button"
+          onClick={handleClose}
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
+          <Icon type="collapse-open" />
+        </button>
+
+        <div className="lab-dialog__header">
+          <div className="lab-dialog__title">{title}</div>
           <button
+            className="lab-dialog__close-button"
             type="button"
-            className="lab-dialog__mobile-close-button"
             onClick={handleClose}
-            onTouchStart={this.handleTouchStart}
-            onTouchEnd={this.handleTouchEnd}
+            {...(isModal ? { tabIndex: "2" } : undefined)}
           >
-            <Icon type="collapse-open" />
+            <Icon type="remove" className="lab-dialog__close-button-icon" />
           </button>
-
-          <div className="lab-dialog__header">
-            <div className="lab-dialog__title">{title}</div>
-            <button
-              className="lab-dialog__close-button"
-              type="button"
-              onClick={handleClose}
-              {...(isModal ? { tabIndex: "2" } : undefined)}
-            >
-              <Icon type="remove" className="lab-dialog__close-button-icon" />
-            </button>
-          </div>
-
-          <p className="lab-dialog__body">{content}</p>
-
-          <div className="lab-dialog__footer">
-            {outlineButtonProps ? (
-              <OutlineButton
-                size="normal"
-                text={outlineButtonProps.text}
-                onClick={outlineButtonProps.onClick}
-                {...(isModal ? { tabIndex: "3" } : undefined)}
-              />
-            ) : undefined}
-            <Button
-              size="normal"
-              text={buttonProps.text}
-              onClick={buttonProps.onClick}
-              {...(isModal ? { tabIndex: "1" } : undefined)}
-            />
-          </div>
         </div>
-      </DialogWrapper>
-    );
-  }
+
+        <p className="lab-dialog__body">{content}</p>
+
+        <div className="lab-dialog__footer">
+          {outlineButtonProps ? (
+            <OutlineButton
+              size="normal"
+              text={outlineButtonProps.text}
+              onClick={outlineButtonProps.onClick}
+              {...(isModal ? { tabIndex: "3" } : undefined)}
+            />
+          ) : undefined}
+          <Button
+            size="normal"
+            text={buttonProps.text}
+            onClick={buttonProps.onClick}
+            {...(isModal ? { tabIndex: "1" } : undefined)}
+          />
+        </div>
+      </div>
+    </DialogWrapper>
+  );
 }
+
+StandardDialog.propTypes = {
+  title: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  buttonProps: PropTypes.exact({
+    text: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+  }).isRequired,
+  outlineButtonProps: PropTypes.exact({
+    text: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+  }),
+  isLarge: PropTypes.bool,
+  handleClose: PropTypes.func,
+  isOpen: PropTypes.bool,
+  isModal: PropTypes.bool,
+};
+
+StandardDialog.defaultProps = {
+  outlineButtonProps: undefined,
+  isLarge: false,
+  handleClose: () => {},
+  isOpen: false,
+  isModal: false,
+};

--- a/src/Dialog/StandardDialog.test.js
+++ b/src/Dialog/StandardDialog.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";

--- a/src/Dialog/StandardDialog.test.js
+++ b/src/Dialog/StandardDialog.test.js
@@ -20,108 +20,131 @@ const args = {
   isModal: false,
   isOpen: false,
   handleCLose: jest.fn(),
-  isMessageDialog: true,
 };
 
-describe("StandartDialog", () => {
-  it("renders with base props", () => {
-    const Component = <StandardDialog {...args} />;
-    const renderedComponent = renderer.create(Component).toJSON();
-
-    expect(renderedComponent).toMatchSnapshot();
+describe("StandardDialog", () => {
+  afterEach(() => {
+    /* reset html tag after each test case */
+    document.getElementsByTagName("html")[0].innerHTML = "";
   });
 
-  it("test with isOpen false", () => {
+  it("rendering with base props", () => {
+    expect(document.body.style.overflow).toBe("");
+
+    const Component = <StandardDialog {...args} />;
+    const renderedComponent = renderer.create(Component);
+
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+  });
+
+  it("rendering with isOpen false", () => {
+    expect(document.body.style.overflow).toBe("");
+
     const Component = (
       <StandardDialog {...args} isModal isLarge isOpen={false} />
     );
-    const renderedComponent = renderer.create(Component).toJSON();
+    const renderedComponent = renderer.create(Component);
 
-    expect(renderedComponent).toMatchSnapshot();
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+
+    expect(document.body.style.overflow).toBe("");
   });
 
-  it("test with isModal false", () => {
+  it("rendering with isModal false", () => {
+    expect(document.body.style.overflow).toBe("");
+
     const Component = (
       <StandardDialog {...args} isModal={false} isLarge isOpen />
     );
-    const renderedComponent = renderer.create(Component).toJSON();
+    const renderedComponent = renderer.create(Component);
 
-    expect(renderedComponent).toMatchSnapshot();
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
 
-  it("test with isLarge false", () => {
+  it("rendering with isLarge false", () => {
+    expect(document.body.style.overflow).toBe("");
+
     const Component = (
       <StandardDialog {...args} isModal isOpen isLarge={false} />
     );
-    const renderedComponent = renderer.create(Component).toJSON();
+    const renderedComponent = renderer.create(Component);
 
-    expect(renderedComponent).toMatchSnapshot();
+    expect(renderedComponent.toJSON()).toMatchSnapshot();
+
+    /* To clean up things */
+    renderedComponent.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
 
-  it(`checks if isOpen false sets body overflow to `, () => {
-    let isOpen = false;
-    const handleClose = () => {
-      isOpen = false;
-    };
+  it(`rendering if isOpen false sets body overflow to empty`, () => {
+    expect(document.body.style.overflow).toBe("");
 
-    const Component = (
+    const wrapper = mount(
       <StandardDialog
         {...args}
-        isModal
-        isOpen={isOpen}
-        handleClose={handleClose}
+        isModal // true
+        isOpen={false}
       />
     );
 
-    const renderedComponent = renderer.create(Component).toJSON();
-    const wrapper = mount(Component);
-    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.overflow).toBe("");
 
     expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
     expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
 
-    expect(renderedComponent).toMatchSnapshot();
+    wrapper.unmount();
   });
-  it("checks if isOpen true sets body overflow to hidden", () => {
-    let isOpen = true;
-    const handleClose = () => {
-      isOpen = false;
-    };
-    const Component = (
+  it("checks if isOpen and isModal true sets body overflow to hidden", () => {
+    expect(document.body.style.overflow).toBe("");
+
+    const wrapper = mount(
       <StandardDialog
         {...args}
-        isModal
-        isOpen={isOpen}
-        handleClose={handleClose}
+        isModal // true
+        isOpen // true
       />
     );
 
-    const renderedComponent = renderer.create(Component).toJSON();
-    const wrapper = mount(Component);
     expect(document.body.style.overflow).toBe("hidden");
+
     expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
     expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
 
-    expect(renderedComponent).toMatchSnapshot();
+    wrapper.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
   it("toggle isOpen", () => {
-    const handleClose = () => {};
-    const Component = (
-      <StandardDialog {...args} isModal isOpen handleClose={handleClose} />
-    );
-    const renderedComponent = renderer.create(Component).toJSON();
-    const wrapper = mount(Component);
+    expect(document.body.style.overflow).toBe("");
+
+    const wrapper = mount(<StandardDialog {...args} isModal isOpen />);
 
     expect(document.body.style.overflow).toBe("hidden");
+
     expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
     expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
 
     wrapper.setProps({ isOpen: false });
 
     expect(document.body.style.overflow).toBe("unset");
+
     expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
     expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
 
-    expect(renderedComponent).toMatchSnapshot();
+    wrapper.unmount();
+
+    expect(document.body.style.overflow).toBe("unset");
   });
 });

--- a/src/Dialog/StandardDialog.test.js
+++ b/src/Dialog/StandardDialog.test.js
@@ -1,0 +1,127 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { mount } from "enzyme";
+
+import { StandardDialog } from "./index";
+
+const args = {
+  title: "Sample Message Dialog",
+  icon: "star",
+  content:
+    "This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.",
+  buttonProps: {
+    text: "Required button",
+    onClick: () => alert("Required button clicked"),
+  },
+  outlineButtonProps: {
+    text: "Optional button",
+    onClick: () => alert("Optional button clicked"),
+  },
+  isModal: false,
+  isOpen: false,
+  handleCLose: jest.fn(),
+  isMessageDialog: true,
+};
+
+describe("StandartDialog", () => {
+  it("renders with base props", () => {
+    const Component = <StandardDialog {...args} />;
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isOpen false", () => {
+    const Component = (
+      <StandardDialog {...args} isModal isLarge isOpen={false} />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isModal false", () => {
+    const Component = (
+      <StandardDialog {...args} isModal={false} isLarge isOpen />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it("test with isLarge false", () => {
+    const Component = (
+      <StandardDialog {...args} isModal isOpen isLarge={false} />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it(`checks if isOpen false sets body overflow to `, () => {
+    let isOpen = false;
+    const handleClose = () => {
+      isOpen = false;
+    };
+
+    const Component = (
+      <StandardDialog
+        {...args}
+        isModal
+        isOpen={isOpen}
+        handleClose={handleClose}
+      />
+    );
+
+    const renderedComponent = renderer.create(Component).toJSON();
+    const wrapper = mount(Component);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
+    expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+  it("checks if isOpen true sets body overflow to hidden", () => {
+    let isOpen = true;
+    const handleClose = () => {
+      isOpen = false;
+    };
+    const Component = (
+      <StandardDialog
+        {...args}
+        isModal
+        isOpen={isOpen}
+        handleClose={handleClose}
+      />
+    );
+
+    const renderedComponent = renderer.create(Component).toJSON();
+    const wrapper = mount(Component);
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
+    expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+  it("toggle isOpen", () => {
+    const handleClose = () => {};
+    const Component = (
+      <StandardDialog {...args} isModal isOpen handleClose={handleClose} />
+    );
+    const renderedComponent = renderer.create(Component).toJSON();
+    const wrapper = mount(Component);
+
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(wrapper.find(".lab-dialog__title").text()).toBe(args.title);
+    expect(wrapper.find(".lab-dialog__body").text()).toBe(args.content);
+
+    wrapper.setProps({ isOpen: false });
+
+    expect(document.body.style.overflow).toBe("unset");
+    expect(wrapper.find(".lab-dialog__title").exists()).toBeFalsy();
+    expect(wrapper.find(".lab-dialog__body").exists()).toBeFalsy();
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+});

--- a/src/Dialog/__snapshots__/DialogWrapper.test.js.snap
+++ b/src/Dialog/__snapshots__/DialogWrapper.test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DialogWrapper renders with base props 1`] = `
+<div
+  className="lab-dialog lab-dialog--message
+            "
+>
+  <div />
+</div>
+`;
+
+exports[`DialogWrapper test with isLarge false 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[MockFunction]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--message
+            "
+  >
+    <div />
+  </div>,
+]
+`;
+
+exports[`DialogWrapper test with isMessageDialog false 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[MockFunction]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--standard
+             lab-dialog--large"
+  >
+    <div />
+  </div>,
+]
+`;
+
+exports[`DialogWrapper test with isModal false 1`] = `
+<div
+  className="lab-dialog lab-dialog--message
+             lab-dialog--large"
+>
+  <div />
+</div>
+`;
+
+exports[`DialogWrapper test with isOpen false 1`] = `
+<div
+  className="lab-dialog lab-dialog--message
+             lab-dialog--large"
+>
+  <div />
+</div>
+`;

--- a/src/Dialog/__snapshots__/MessageDialog.test.js.snap
+++ b/src/Dialog/__snapshots__/MessageDialog.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MessageDialog checks if isOpen false sets body overflow to  1`] = `null`;
+exports[`MessageDialog rendering with base props 1`] = `null`;
 
-exports[`MessageDialog checks if isOpen true sets body overflow to hidden 1`] = `
+exports[`MessageDialog rendering with isLarge false 1`] = `
 Array [
   <div
     className="lab-dialog-overlay"
@@ -87,94 +87,7 @@ Array [
 ]
 `;
 
-exports[`MessageDialog renders with base props 1`] = `null`;
-
-exports[`MessageDialog test with isLarge false 1`] = `
-Array [
-  <div
-    className="lab-dialog-overlay"
-    onClick={[Function]}
-    role="presentation"
-  />,
-  <div
-    className="lab-dialog lab-dialog--message
-            "
-  >
-    <div
-      aria-modal="true"
-      className="lab-dialog__content lab-dialog__content--message"
-      role="dialog"
-    >
-      <button
-        className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
-        onClick={[Function]}
-        onTouchEnd={[Function]}
-        onTouchStart={[Function]}
-        type="button"
-      >
-        <span
-          className="lab-icon lab-icon--collapse-open"
-        />
-      </button>
-      <div
-        className="lab-dialog__header lab-dialog__header--message"
-      >
-        <button
-          className="lab-dialog__close-button"
-          onClick={[Function]}
-          tabIndex="2"
-          type="button"
-        >
-          <span
-            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
-          />
-        </button>
-      </div>
-      <div
-        className="lab-dialog__icon-wrapper"
-      >
-        <span
-          className="lab-icon lab-icon--star lab-dialog__icon"
-        />
-      </div>
-      <div
-        className="lab-dialog__title lab-dialog__title--message"
-      >
-        Sample Message Dialog
-      </div>
-      <div
-        className="lab-dialog__body lab-dialog__body--message"
-      >
-        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
-      </div>
-      <div
-        className="lab-dialog__footer lab-dialog__footer--message"
-      >
-        <button
-          className="lab-btn lab-btn--outline lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="3"
-          type="button"
-        >
-          
-          Optional button
-        </button>
-        <button
-          className="lab-btn lab-btn--default lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="1"
-          type="button"
-        >
-          
-          Required button
-        </button>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`MessageDialog test with isModal false 1`] = `
+exports[`MessageDialog rendering with isModal false 1`] = `
 <div
   className="lab-dialog lab-dialog--message
              lab-dialog--large"
@@ -249,89 +162,4 @@ exports[`MessageDialog test with isModal false 1`] = `
 </div>
 `;
 
-exports[`MessageDialog test with isOpen false 1`] = `null`;
-
-exports[`MessageDialog toggle isOpen 1`] = `
-Array [
-  <div
-    className="lab-dialog-overlay"
-    onClick={[Function]}
-    role="presentation"
-  />,
-  <div
-    className="lab-dialog lab-dialog--message
-            "
-  >
-    <div
-      aria-modal="true"
-      className="lab-dialog__content lab-dialog__content--message"
-      role="dialog"
-    >
-      <button
-        className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
-        onClick={[Function]}
-        onTouchEnd={[Function]}
-        onTouchStart={[Function]}
-        type="button"
-      >
-        <span
-          className="lab-icon lab-icon--collapse-open"
-        />
-      </button>
-      <div
-        className="lab-dialog__header lab-dialog__header--message"
-      >
-        <button
-          className="lab-dialog__close-button"
-          onClick={[Function]}
-          tabIndex="2"
-          type="button"
-        >
-          <span
-            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
-          />
-        </button>
-      </div>
-      <div
-        className="lab-dialog__icon-wrapper"
-      >
-        <span
-          className="lab-icon lab-icon--star lab-dialog__icon"
-        />
-      </div>
-      <div
-        className="lab-dialog__title lab-dialog__title--message"
-      >
-        Sample Message Dialog
-      </div>
-      <div
-        className="lab-dialog__body lab-dialog__body--message"
-      >
-        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
-      </div>
-      <div
-        className="lab-dialog__footer lab-dialog__footer--message"
-      >
-        <button
-          className="lab-btn lab-btn--outline lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="3"
-          type="button"
-        >
-          
-          Optional button
-        </button>
-        <button
-          className="lab-btn lab-btn--default lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="1"
-          type="button"
-        >
-          
-          Required button
-        </button>
-      </div>
-    </div>
-  </div>,
-]
-`;
+exports[`MessageDialog rendering with isOpen false 1`] = `null`;

--- a/src/Dialog/__snapshots__/MessageDialog.test.js.snap
+++ b/src/Dialog/__snapshots__/MessageDialog.test.js.snap
@@ -1,0 +1,337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MessageDialog checks if isOpen false sets body overflow to  1`] = `null`;
+
+exports[`MessageDialog checks if isOpen true sets body overflow to hidden 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--message
+            "
+  >
+    <div
+      aria-modal="true"
+      className="lab-dialog__content lab-dialog__content--message"
+      role="dialog"
+    >
+      <button
+        className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
+        onClick={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--collapse-open"
+        />
+      </button>
+      <div
+        className="lab-dialog__header lab-dialog__header--message"
+      >
+        <button
+          className="lab-dialog__close-button"
+          onClick={[Function]}
+          tabIndex="2"
+          type="button"
+        >
+          <span
+            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+          />
+        </button>
+      </div>
+      <div
+        className="lab-dialog__icon-wrapper"
+      >
+        <span
+          className="lab-icon lab-icon--star lab-dialog__icon"
+        />
+      </div>
+      <div
+        className="lab-dialog__title lab-dialog__title--message"
+      >
+        Sample Message Dialog
+      </div>
+      <div
+        className="lab-dialog__body lab-dialog__body--message"
+      >
+        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+      </div>
+      <div
+        className="lab-dialog__footer lab-dialog__footer--message"
+      >
+        <button
+          className="lab-btn lab-btn--outline lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="3"
+          type="button"
+        >
+          
+          Optional button
+        </button>
+        <button
+          className="lab-btn lab-btn--default lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="1"
+          type="button"
+        >
+          
+          Required button
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`MessageDialog renders with base props 1`] = `null`;
+
+exports[`MessageDialog test with isLarge false 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--message
+            "
+  >
+    <div
+      aria-modal="true"
+      className="lab-dialog__content lab-dialog__content--message"
+      role="dialog"
+    >
+      <button
+        className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
+        onClick={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--collapse-open"
+        />
+      </button>
+      <div
+        className="lab-dialog__header lab-dialog__header--message"
+      >
+        <button
+          className="lab-dialog__close-button"
+          onClick={[Function]}
+          tabIndex="2"
+          type="button"
+        >
+          <span
+            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+          />
+        </button>
+      </div>
+      <div
+        className="lab-dialog__icon-wrapper"
+      >
+        <span
+          className="lab-icon lab-icon--star lab-dialog__icon"
+        />
+      </div>
+      <div
+        className="lab-dialog__title lab-dialog__title--message"
+      >
+        Sample Message Dialog
+      </div>
+      <div
+        className="lab-dialog__body lab-dialog__body--message"
+      >
+        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+      </div>
+      <div
+        className="lab-dialog__footer lab-dialog__footer--message"
+      >
+        <button
+          className="lab-btn lab-btn--outline lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="3"
+          type="button"
+        >
+          
+          Optional button
+        </button>
+        <button
+          className="lab-btn lab-btn--default lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="1"
+          type="button"
+        >
+          
+          Required button
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`MessageDialog test with isModal false 1`] = `
+<div
+  className="lab-dialog lab-dialog--message
+             lab-dialog--large"
+>
+  <div
+    aria-modal="true"
+    className="lab-dialog__content lab-dialog__content--message"
+    role="dialog"
+  >
+    <button
+      className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
+      onClick={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <span
+        className="lab-icon lab-icon--collapse-open"
+      />
+    </button>
+    <div
+      className="lab-dialog__header lab-dialog__header--message"
+    >
+      <button
+        className="lab-dialog__close-button"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+        />
+      </button>
+    </div>
+    <div
+      className="lab-dialog__icon-wrapper"
+    >
+      <span
+        className="lab-icon lab-icon--star lab-dialog__icon"
+      />
+    </div>
+    <div
+      className="lab-dialog__title lab-dialog__title--message"
+    >
+      Sample Message Dialog
+    </div>
+    <div
+      className="lab-dialog__body lab-dialog__body--message"
+    >
+      This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+    </div>
+    <div
+      className="lab-dialog__footer lab-dialog__footer--message"
+    >
+      <button
+        className="lab-btn lab-btn--outline lab-btn--normal"
+        onClick={[Function]}
+        type="button"
+      >
+        
+        Optional button
+      </button>
+      <button
+        className="lab-btn lab-btn--default lab-btn--normal"
+        onClick={[Function]}
+        type="button"
+      >
+        
+        Required button
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MessageDialog test with isOpen false 1`] = `null`;
+
+exports[`MessageDialog toggle isOpen 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--message
+            "
+  >
+    <div
+      aria-modal="true"
+      className="lab-dialog__content lab-dialog__content--message"
+      role="dialog"
+    >
+      <button
+        className="lab-dialog__mobile-close-button lab-dialog__mobile-close-button--message"
+        onClick={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--collapse-open"
+        />
+      </button>
+      <div
+        className="lab-dialog__header lab-dialog__header--message"
+      >
+        <button
+          className="lab-dialog__close-button"
+          onClick={[Function]}
+          tabIndex="2"
+          type="button"
+        >
+          <span
+            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+          />
+        </button>
+      </div>
+      <div
+        className="lab-dialog__icon-wrapper"
+      >
+        <span
+          className="lab-icon lab-icon--star lab-dialog__icon"
+        />
+      </div>
+      <div
+        className="lab-dialog__title lab-dialog__title--message"
+      >
+        Sample Message Dialog
+      </div>
+      <div
+        className="lab-dialog__body lab-dialog__body--message"
+      >
+        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+      </div>
+      <div
+        className="lab-dialog__footer lab-dialog__footer--message"
+      >
+        <button
+          className="lab-btn lab-btn--outline lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="3"
+          type="button"
+        >
+          
+          Optional button
+        </button>
+        <button
+          className="lab-btn lab-btn--default lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="1"
+          type="button"
+        >
+          
+          Required button
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/src/Dialog/__snapshots__/StandardDialog.test.js.snap
+++ b/src/Dialog/__snapshots__/StandardDialog.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StandartDialog checks if isOpen false sets body overflow to  1`] = `null`;
+exports[`StandardDialog rendering with base props 1`] = `null`;
 
-exports[`StandartDialog checks if isOpen true sets body overflow to hidden 1`] = `
+exports[`StandardDialog rendering with isLarge false 1`] = `
 Array [
   <div
     className="lab-dialog-overlay"
@@ -80,87 +80,7 @@ Array [
 ]
 `;
 
-exports[`StandartDialog renders with base props 1`] = `null`;
-
-exports[`StandartDialog test with isLarge false 1`] = `
-Array [
-  <div
-    className="lab-dialog-overlay"
-    onClick={[Function]}
-    role="presentation"
-  />,
-  <div
-    className="lab-dialog lab-dialog--standard
-            "
-  >
-    <div
-      aria-modal="true"
-      className="lab-dialog__content"
-      role="dialog"
-    >
-      <button
-        className="lab-dialog__mobile-close-button"
-        onClick={[Function]}
-        onTouchEnd={[Function]}
-        onTouchStart={[Function]}
-        type="button"
-      >
-        <span
-          className="lab-icon lab-icon--collapse-open"
-        />
-      </button>
-      <div
-        className="lab-dialog__header"
-      >
-        <div
-          className="lab-dialog__title"
-        >
-          Sample Message Dialog
-        </div>
-        <button
-          className="lab-dialog__close-button"
-          onClick={[Function]}
-          tabIndex="2"
-          type="button"
-        >
-          <span
-            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
-          />
-        </button>
-      </div>
-      <p
-        className="lab-dialog__body"
-      >
-        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
-      </p>
-      <div
-        className="lab-dialog__footer"
-      >
-        <button
-          className="lab-btn lab-btn--outline lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="3"
-          type="button"
-        >
-          
-          Optional button
-        </button>
-        <button
-          className="lab-btn lab-btn--default lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="1"
-          type="button"
-        >
-          
-          Required button
-        </button>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`StandartDialog test with isModal false 1`] = `
+exports[`StandardDialog rendering with isModal false 1`] = `
 <div
   className="lab-dialog lab-dialog--standard
              lab-dialog--large"
@@ -228,82 +148,4 @@ exports[`StandartDialog test with isModal false 1`] = `
 </div>
 `;
 
-exports[`StandartDialog test with isOpen false 1`] = `null`;
-
-exports[`StandartDialog toggle isOpen 1`] = `
-Array [
-  <div
-    className="lab-dialog-overlay"
-    onClick={[Function]}
-    role="presentation"
-  />,
-  <div
-    className="lab-dialog lab-dialog--standard
-            "
-  >
-    <div
-      aria-modal="true"
-      className="lab-dialog__content"
-      role="dialog"
-    >
-      <button
-        className="lab-dialog__mobile-close-button"
-        onClick={[Function]}
-        onTouchEnd={[Function]}
-        onTouchStart={[Function]}
-        type="button"
-      >
-        <span
-          className="lab-icon lab-icon--collapse-open"
-        />
-      </button>
-      <div
-        className="lab-dialog__header"
-      >
-        <div
-          className="lab-dialog__title"
-        >
-          Sample Message Dialog
-        </div>
-        <button
-          className="lab-dialog__close-button"
-          onClick={[Function]}
-          tabIndex="2"
-          type="button"
-        >
-          <span
-            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
-          />
-        </button>
-      </div>
-      <p
-        className="lab-dialog__body"
-      >
-        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
-      </p>
-      <div
-        className="lab-dialog__footer"
-      >
-        <button
-          className="lab-btn lab-btn--outline lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="3"
-          type="button"
-        >
-          
-          Optional button
-        </button>
-        <button
-          className="lab-btn lab-btn--default lab-btn--normal"
-          onClick={[Function]}
-          tabIndex="1"
-          type="button"
-        >
-          
-          Required button
-        </button>
-      </div>
-    </div>
-  </div>,
-]
-`;
+exports[`StandardDialog rendering with isOpen false 1`] = `null`;

--- a/src/Dialog/__snapshots__/StandardDialog.test.js.snap
+++ b/src/Dialog/__snapshots__/StandardDialog.test.js.snap
@@ -1,0 +1,309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StandartDialog checks if isOpen false sets body overflow to  1`] = `null`;
+
+exports[`StandartDialog checks if isOpen true sets body overflow to hidden 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--standard
+            "
+  >
+    <div
+      aria-modal="true"
+      className="lab-dialog__content"
+      role="dialog"
+    >
+      <button
+        className="lab-dialog__mobile-close-button"
+        onClick={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--collapse-open"
+        />
+      </button>
+      <div
+        className="lab-dialog__header"
+      >
+        <div
+          className="lab-dialog__title"
+        >
+          Sample Message Dialog
+        </div>
+        <button
+          className="lab-dialog__close-button"
+          onClick={[Function]}
+          tabIndex="2"
+          type="button"
+        >
+          <span
+            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+          />
+        </button>
+      </div>
+      <p
+        className="lab-dialog__body"
+      >
+        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+      </p>
+      <div
+        className="lab-dialog__footer"
+      >
+        <button
+          className="lab-btn lab-btn--outline lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="3"
+          type="button"
+        >
+          
+          Optional button
+        </button>
+        <button
+          className="lab-btn lab-btn--default lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="1"
+          type="button"
+        >
+          
+          Required button
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`StandartDialog renders with base props 1`] = `null`;
+
+exports[`StandartDialog test with isLarge false 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--standard
+            "
+  >
+    <div
+      aria-modal="true"
+      className="lab-dialog__content"
+      role="dialog"
+    >
+      <button
+        className="lab-dialog__mobile-close-button"
+        onClick={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--collapse-open"
+        />
+      </button>
+      <div
+        className="lab-dialog__header"
+      >
+        <div
+          className="lab-dialog__title"
+        >
+          Sample Message Dialog
+        </div>
+        <button
+          className="lab-dialog__close-button"
+          onClick={[Function]}
+          tabIndex="2"
+          type="button"
+        >
+          <span
+            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+          />
+        </button>
+      </div>
+      <p
+        className="lab-dialog__body"
+      >
+        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+      </p>
+      <div
+        className="lab-dialog__footer"
+      >
+        <button
+          className="lab-btn lab-btn--outline lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="3"
+          type="button"
+        >
+          
+          Optional button
+        </button>
+        <button
+          className="lab-btn lab-btn--default lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="1"
+          type="button"
+        >
+          
+          Required button
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`StandartDialog test with isModal false 1`] = `
+<div
+  className="lab-dialog lab-dialog--standard
+             lab-dialog--large"
+>
+  <div
+    aria-modal="true"
+    className="lab-dialog__content"
+    role="dialog"
+  >
+    <button
+      className="lab-dialog__mobile-close-button"
+      onClick={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      type="button"
+    >
+      <span
+        className="lab-icon lab-icon--collapse-open"
+      />
+    </button>
+    <div
+      className="lab-dialog__header"
+    >
+      <div
+        className="lab-dialog__title"
+      >
+        Sample Message Dialog
+      </div>
+      <button
+        className="lab-dialog__close-button"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+        />
+      </button>
+    </div>
+    <p
+      className="lab-dialog__body"
+    >
+      This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+    </p>
+    <div
+      className="lab-dialog__footer"
+    >
+      <button
+        className="lab-btn lab-btn--outline lab-btn--normal"
+        onClick={[Function]}
+        type="button"
+      >
+        
+        Optional button
+      </button>
+      <button
+        className="lab-btn lab-btn--default lab-btn--normal"
+        onClick={[Function]}
+        type="button"
+      >
+        
+        Required button
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StandartDialog test with isOpen false 1`] = `null`;
+
+exports[`StandartDialog toggle isOpen 1`] = `
+Array [
+  <div
+    className="lab-dialog-overlay"
+    onClick={[Function]}
+    role="presentation"
+  />,
+  <div
+    className="lab-dialog lab-dialog--standard
+            "
+  >
+    <div
+      aria-modal="true"
+      className="lab-dialog__content"
+      role="dialog"
+    >
+      <button
+        className="lab-dialog__mobile-close-button"
+        onClick={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        type="button"
+      >
+        <span
+          className="lab-icon lab-icon--collapse-open"
+        />
+      </button>
+      <div
+        className="lab-dialog__header"
+      >
+        <div
+          className="lab-dialog__title"
+        >
+          Sample Message Dialog
+        </div>
+        <button
+          className="lab-dialog__close-button"
+          onClick={[Function]}
+          tabIndex="2"
+          type="button"
+        >
+          <span
+            className="lab-icon lab-icon--remove lab-dialog__close-button-icon"
+          />
+        </button>
+      </div>
+      <p
+        className="lab-dialog__body"
+      >
+        This is the main content of a Message Dialog. You may want to put as much content as you want, as long as it's a string.
+      </p>
+      <div
+        className="lab-dialog__footer"
+      >
+        <button
+          className="lab-btn lab-btn--outline lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="3"
+          type="button"
+        >
+          
+          Optional button
+        </button>
+        <button
+          className="lab-btn lab-btn--default lab-btn--normal"
+          onClick={[Function]}
+          tabIndex="1"
+          type="button"
+        >
+          
+          Required button
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;


### PR DESCRIPTION
**Link to task:**
[Jira#314](https://labcodes.atlassian.net/browse/CSYS-314)

**Staging app:** 
https://CSYS-314-migrate-dialog-to-fn-component--confetti-storybook.netlify.app/

**How to test:**
Run all the tests to check if the component crash

**Description of your solution:**
I migrated the DialogWrapper, MessageDialog and StandardDialog to function component. I also created tests for them.
After each test case, I reset the JSDOM with [this snippet](https://gist.github.com/Tahul/d98ec315eeaa24ab691649783f25dafd). Then I check if the `document.body.style.overflow` is empty before execute the test and after the test run I check if the overflow is `unset`.

**Screenshots (when applicable):**
N/A
