### PR TITLE
[CSYS-366] Migrating DropdownSectionTitle, TagDropdownItem and TagDropdown to Hooks

### DIFF
--- a/src/Dropdown/DropdownSectionTitle.js
+++ b/src/Dropdown/DropdownSectionTitle.js
@@ -1,26 +1,23 @@
-import React, { Component } from "react";
+import React from "react";
 import { PropTypes } from "prop-types";
 
-export default class DropdownSectionTitle extends Component {
-  static propTypes = {
-    /** This is DropdownSectionTitle's title */
-    text: PropTypes.node.isRequired,
-    /** This is DropdownSectionTitle's color. The color is inherit from dropdown color  */
-    color: PropTypes.string,
-  };
-
-  static defaultProps = {
-    color: "teal",
-  };
-
-  render() {
-    const { text, color } = this.props;
-    return (
-      <span
-        className={`lab-dropdown__section-title lab-dropdown__section-title--color-${color}`}
-      >
-        {text}
-      </span>
-    );
-  }
+export default function DropdownSectionTitle({ text, color }) {
+  return (
+    <span
+      className={`lab-dropdown__section-title lab-dropdown__section-title--color-${color}`}
+    >
+      {text}
+    </span>
+  );
 }
+
+DropdownSectionTitle.propTypes = {
+  /** This is DropdownSectionTitle's title */
+  text: PropTypes.node.isRequired,
+  /** This is DropdownSectionTitle's color. The color is inherit from dropdown color  */
+  color: PropTypes.string,
+};
+
+DropdownSectionTitle.defaultProps = {
+  color: "teal",
+};

--- a/src/Dropdown/TagDropdown.js
+++ b/src/Dropdown/TagDropdown.js
@@ -1,59 +1,56 @@
-import React, { Component } from "react";
+import React from "react";
 import { PropTypes } from "prop-types";
 
 import AbstractDropdown from "./AbstractDropdown";
 
-export default class TagDropdown extends Component {
-  static propTypes = {
-    /** Function called after the dropdown is opened. */
-    onOpen: PropTypes.func,
-    /** Function called after the dropdown is closed. */
-    onClose: PropTypes.func,
-    /** Function called when the user selects one valid option. */
-    onSelect: PropTypes.func.isRequired,
-    /** This is the dropdown color, and it will set the color of its section title and trigger. */
-    color: PropTypes.string,
-    /** This is the dropdown default trigger title. It will mount with this default text until the user selects an option. */
-    defaultText: PropTypes.string.isRequired,
-    /** This is the dropdown of children. It can be a TagItem or a SectionTitle, and if the user doesn't pass a child, it will throw an error. */
-    children: PropTypes.node.isRequired,
-    /** This is the dropdown id. It requires a unique id. */
-    id: PropTypes.string.isRequired,
-    /** This is the controlled value of the TagDropdown */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  };
-
-  static defaultProps = {
-    color: "teal",
-    onOpen: () => {},
-    onClose: () => {},
-    value: "",
-  };
-
-  render() {
-    const {
-      children,
-      defaultText,
-      color,
-      onOpen,
-      onClose,
-      onSelect,
-      id,
-      value,
-    } = this.props;
-    return (
-      <AbstractDropdown
-        dropdownType="tag"
-        defaultText={defaultText}
-        color={color}
-        onOpen={onOpen}
-        onClose={onClose}
-        onSelect={onSelect}
-        id={id}
-        value={value}
-      >
-        {children}
-      </AbstractDropdown>
-    );
-  }
+export default function TagDropdown({
+  children,
+  defaultText,
+  color,
+  onOpen,
+  onClose,
+  onSelect,
+  id,
+  value,
+}) {
+  return (
+    <AbstractDropdown
+      dropdownType="tag"
+      defaultText={defaultText}
+      color={color}
+      onOpen={onOpen}
+      onClose={onClose}
+      onSelect={onSelect}
+      id={id}
+      value={value}
+    >
+      {children}
+    </AbstractDropdown>
+  );
 }
+
+TagDropdown.propTypes = {
+  /** Function called after the dropdown is opened. */
+  onOpen: PropTypes.func,
+  /** Function called after the dropdown is closed. */
+  onClose: PropTypes.func,
+  /** Function called when the user selects one valid option. */
+  onSelect: PropTypes.func.isRequired,
+  /** This is the dropdown color, and it will set the color of its section title and trigger. */
+  color: PropTypes.string,
+  /** This is the dropdown default trigger title. It will mount with this default text until the user selects an option. */
+  defaultText: PropTypes.string.isRequired,
+  /** This is the dropdown of children. It can be a TagItem or a SectionTitle, and if the user doesn't pass a child, it will throw an error. */
+  children: PropTypes.node.isRequired,
+  /** This is the dropdown id. It requires a unique id. */
+  id: PropTypes.string.isRequired,
+  /** This is the controlled value of the TagDropdown */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+TagDropdown.defaultProps = {
+  color: "teal",
+  onOpen: () => {},
+  onClose: () => {},
+  value: "",
+};

--- a/src/Dropdown/TagDropdownItem.js
+++ b/src/Dropdown/TagDropdownItem.js
@@ -21,30 +21,12 @@ export default function TagDropdownItem({
   value,
   isSelected,
 }) {
-  const checkThumbAndIcon = (thumbSrc, icon) => {
-    const errorMessage =
-      "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props.";
-    if (!isEmpty(thumbSrc) && !isEmpty(icon)) {
-      throw new Error(errorMessage);
-    }
-  };
-
-  // super constructor
-  const handleCheckThumbAndIcon = useCallback(() => {
-    checkThumbAndIcon();
-  }, [icon, thumbSrc]);
-
-  // componentDidUpdate
-  useEffect(() => {
-    handleCheckThumbAndIcon();
-  }, []);
-
-  const renderThumb = ({ thumbSrc }) =>
+  const renderThumb = () =>
     thumbSrc ? (
       <img className="lab-tag__thumb" src={thumbSrc} alt="" />
     ) : undefined;
 
-  const renderIcon = ({ icon }) =>
+  const renderIcon = () =>
     icon ? (
       <Icon
         type={icon}
@@ -53,6 +35,28 @@ export default function TagDropdownItem({
         className="lab-tag--left-icon"
       />
     ) : undefined;
+  //
+  // const checkThumbAndIcon = ({ thumbSrc, icon }) => {
+  //   const errorMessage =
+  //     "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props.";
+  //   if (!isEmpty(thumbSrc) && !isEmpty(icon)) {
+  //     throw new Error(errorMessage);
+  //   }
+  // };
+
+  // super constructor
+  const checkThumbAndIcon = useCallback(() => {
+    const errorMessage =
+      "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props.";
+    if (!isEmpty(thumbSrc) && !isEmpty(icon)) {
+      throw new Error(errorMessage);
+    }
+  }, [thumbSrc, icon]);
+
+  // componentDidUpdate
+  useEffect(() => {
+    checkThumbAndIcon();
+  }, [thumbSrc, icon]);
 
   return (
     <AbstractTag
@@ -63,7 +67,7 @@ export default function TagDropdownItem({
       isOutline={isOutline}
       skin={skin}
       color={color}
-      renderPrefix={renderIcon(icon) || renderThumb(thumbSrc)}
+      renderPrefix={renderThumb() || renderIcon()}
       onClick={onClick}
       disabled={disabled}
       tabIndex={tabIndex}

--- a/src/Dropdown/TagDropdownItem.js
+++ b/src/Dropdown/TagDropdownItem.js
@@ -35,14 +35,6 @@ export default function TagDropdownItem({
         className="lab-tag--left-icon"
       />
     ) : undefined;
-  //
-  // const checkThumbAndIcon = ({ thumbSrc, icon }) => {
-  //   const errorMessage =
-  //     "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props.";
-  //   if (!isEmpty(thumbSrc) && !isEmpty(icon)) {
-  //     throw new Error(errorMessage);
-  //   }
-  // };
 
   // super constructor
   const checkThumbAndIcon = useCallback(() => {

--- a/src/Dropdown/TagDropdownItem.js
+++ b/src/Dropdown/TagDropdownItem.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { isEmpty } from "lodash";
 
@@ -6,69 +6,46 @@ import Icon from "../Icon";
 import { ICON_TYPES, TAG_COLORS } from "../constants";
 import AbstractTag from "../Tags/AbstractTag";
 
-export default class TagDropdownItem extends React.Component {
-  static propTypes = {
-    /** This is the Tag's text. */
-    text: PropTypes.string.isRequired,
-    /** Disables the Tag. Won't be read by screen readers. */
-    disabled: PropTypes.bool,
-    /** Action to be executed when the Tag is clicked. */
-    onClick: PropTypes.func,
-    /** Source of the thumb to be rendered. Won't render a thumb if not passed to the component. Can't have both 'icon' and 'thumbSrc' at the same time. */
-    thumbSrc: PropTypes.string,
-    /** Type of the icon to be rendered. Won't render an icon if not passed to the component. Can't have both 'icon' and 'thumbSrc' at the same time. */
-    icon: PropTypes.oneOf(ICON_TYPES),
-    /** Sets Tag's color. */
-    color: PropTypes.oneOf(TAG_COLORS),
-    /** Skin of the the rendered Tag. */
-    skin: PropTypes.oneOf(["pale", "vivid"]),
-    /** Sets an outline style. */
-    isOutline: PropTypes.bool,
-    /** Option tab index */
-    tabIndex: PropTypes.string,
-    /** This function is used on AbstractTag's componenentDidMount to set the current Ref */
-    setRef: PropTypes.func,
-    /** This function is used to handle click or keydown interactions */
-    onInteraction: PropTypes.func,
-    /** This is the option's value */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    /** This prop is a boolean to verify if the option is current selected  */
-    isSelected: PropTypes.bool,
+export default function TagDropdownItem({
+  text,
+  thumbSrc,
+  icon,
+  color,
+  skin,
+  isOutline,
+  onClick,
+  disabled,
+  tabIndex,
+  onInteraction,
+  setRef,
+  value,
+  isSelected,
+}) {
+  const checkThumbAndIcon = (thumbSrc, icon) => {
+    const errorMessage =
+      "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props.";
+    if (!isEmpty(thumbSrc) && !isEmpty(icon)) {
+      throw new Error(errorMessage);
+    }
   };
 
-  static defaultProps = {
-    thumbSrc: "",
-    icon: undefined,
-    isOutline: false,
-    skin: "pale",
-    color: undefined,
-    disabled: false,
-    onClick: () => {},
-    setRef: () => {},
-    onInteraction: () => {},
-    tabIndex: "0",
-    isSelected: false,
-  };
+  // super constructor
+  const handleCheckThumbAndIcon = useCallback(() => {
+    checkThumbAndIcon();
+  }, [icon, thumbSrc]);
 
-  constructor(props) {
-    super(props);
-    this.checkThumbAndIcon();
-  }
+  // componentDidUpdate
+  useEffect(() => {
+    handleCheckThumbAndIcon();
+  }, []);
 
-  componentDidUpdate() {
-    this.checkThumbAndIcon();
-  }
-
-  thumb = () => {
-    const { thumbSrc } = this.props;
-    return thumbSrc ? (
+  const renderThumb = ({ thumbSrc }) =>
+    thumbSrc ? (
       <img className="lab-tag__thumb" src={thumbSrc} alt="" />
     ) : undefined;
-  };
 
-  icon = () => {
-    const { icon } = this.props;
-    return icon ? (
+  const renderIcon = ({ icon }) =>
+    icon ? (
       <Icon
         type={icon}
         color="black-75"
@@ -76,53 +53,69 @@ export default class TagDropdownItem extends React.Component {
         className="lab-tag--left-icon"
       />
     ) : undefined;
-  };
 
-  checkThumbAndIcon() {
-    const errorMessage =
-      "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props.";
-    const { thumbSrc, icon } = this.props;
-    if (!isEmpty(thumbSrc) && !isEmpty(icon)) {
-      throw new Error(errorMessage);
-    }
-  }
-
-  render() {
-    const {
-      text,
-      thumbSrc,
-      icon,
-      color,
-      skin,
-      isOutline,
-      onClick,
-      disabled,
-      tabIndex,
-      onInteraction,
-      setRef,
-      value,
-      isSelected,
-    } = this.props;
-    return (
-      <AbstractTag
-        text={text}
-        className={`lab-tag--togglable${icon ? ` lab-tag--has-left-icon` : ""}${
-          thumbSrc ? ` lab-tag--has-thumb` : ""
-        }`}
-        isOutline={isOutline}
-        skin={skin}
-        color={color}
-        renderPrefix={this.icon() || this.thumb()}
-        onClick={onClick}
-        disabled={disabled}
-        tabIndex={tabIndex}
-        onInteraction={onInteraction}
-        isDropdown
-        setRef={setRef}
-        value={value}
-        isSelected={isSelected}
-        role="option"
-      />
-    );
-  }
+  return (
+    <AbstractTag
+      text={text}
+      className={`lab-tag--togglable${icon ? ` lab-tag--has-left-icon` : ""}${
+        thumbSrc ? ` lab-tag--has-thumb` : ""
+      }`}
+      isOutline={isOutline}
+      skin={skin}
+      color={color}
+      renderPrefix={renderIcon(icon) || renderThumb(thumbSrc)}
+      onClick={onClick}
+      disabled={disabled}
+      tabIndex={tabIndex}
+      onInteraction={onInteraction}
+      isDropdown
+      setRef={setRef}
+      value={value}
+      isSelected={isSelected}
+      role="option"
+    />
+  );
 }
+
+TagDropdownItem.propTypes = {
+  /** This is the Tag's text. */
+  text: PropTypes.string.isRequired,
+  /** Disables the Tag. Won't be read by screen readers. */
+  disabled: PropTypes.bool,
+  /** Action to be executed when the Tag is clicked. */
+  onClick: PropTypes.func,
+  /** Source of the thumb to be rendered. Won't render a thumb if not passed to the component. Can't have both 'icon' and 'thumbSrc' at the same time. */
+  thumbSrc: PropTypes.string,
+  /** Type of the icon to be rendered. Won't render an icon if not passed to the component. Can't have both 'icon' and 'thumbSrc' at the same time. */
+  icon: PropTypes.oneOf(ICON_TYPES),
+  /** Sets Tag's color. */
+  color: PropTypes.oneOf(TAG_COLORS),
+  /** Skin of the rendered Tag. */
+  skin: PropTypes.oneOf(["pale", "vivid"]),
+  /** Sets an outline style. */
+  isOutline: PropTypes.bool,
+  /** Option tab index */
+  tabIndex: PropTypes.string,
+  /** This function is used on AbstractTag's componenentDidMount to set the current Ref */
+  setRef: PropTypes.func,
+  /** This function is used to handle click or keydown interactions */
+  onInteraction: PropTypes.func,
+  /** This is the option's value */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  /** This prop is a boolean to verify if the option is current selected  */
+  isSelected: PropTypes.bool,
+};
+
+TagDropdownItem.defaultProps = {
+  thumbSrc: "",
+  icon: undefined,
+  isOutline: false,
+  skin: "pale",
+  color: undefined,
+  disabled: false,
+  onClick: () => {},
+  setRef: () => {},
+  onInteraction: () => {},
+  tabIndex: "0",
+  isSelected: false,
+};

--- a/src/Dropdown/TagDropdownItem.test.js
+++ b/src/Dropdown/TagDropdownItem.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
 
+import { waitFor } from "@babel/core/lib/gensync-utils/async";
 import TagDropdownItem from "./TagDropdownItem";
 
 describe("TagDropdownItem", () => {
@@ -142,17 +143,20 @@ describe("TagDropdownItem", () => {
   });
 
   it("does not render if passing both `thumb` and `icon` props", async () => {
-    expect(() => {
-      shallow(
-        <TagDropdownItem
-          text="Test to not render TagDropdownItem with with thumb and icon"
-          icon="magnifying-glass"
-          thumbSrc="fake-thumb"
-          value="option1"
-        />
+    // Adding the async method to wait for the promises from the both useCallback and useEffect to be resolved.
+    waitFor(() => {
+      expect(() => {
+        shallow(
+          <TagDropdownItem
+            text="Test to not render TagDropdownItem with with thumb and icon"
+            icon="magnifying-glass"
+            thumbSrc="fake-thumb"
+            value="option1"
+          />
+        );
+      }).toThrow(
+        "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props."
       );
-    }).toThrow(
-      "`TagDropdownItem` can't be initialized with both `thumb` and `icon` props."
-    );
+    });
   });
 });


### PR DESCRIPTION


Link to task:
[CSYS-366](https://labcodes.atlassian.net/browse/CSYS-366), [CSYS-367](https://labcodes.atlassian.net/browse/CSYS-367) and [CSYS-368](https://labcodes.atlassian.net/browse/CSYS-368)

Staging app: CSYS-366-migrate-dropdown-section-title--confetti-storybook.netlify.app/

How to test:
After running your project locally, run the TagDropdownItem.test.js, TagDropdown.test.js and DropdownSectionTitle.test.js in order to check if the TagDropdown component is working as expected.

Description of your solution:

Removing previous mentions from Class Components and moving the Props outside the function and also memoized checkThumbAndIcon callback function. 

Screenshots (when applicable): NA
